### PR TITLE
feat(cli): improve AXI home guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@ This file provides guidance to coding agents when working with code in this repo
 ## Commands
 
 ```sh
+npm run check          # Run build, lint, format check, typecheck, and tests
 npm run build          # esbuild bundle bin/lavish-axi.js -> dist/cli.mjs (ESM, external deps)
 npm test               # node:test runner (test/*.test.js)
 npm run lint           # ESLint over bin src test scripts
@@ -21,7 +22,7 @@ The `prepack` script runs `build` automatically, so publishing always ships a fr
 
 - Node 22+, ESM-only JavaScript (`"type": "module"`). No TypeScript source - `.js` files validated via TS `checkJs`.
 - Use TDD for bug fixes and new features (see `test-driven-development` skill).
-- Run `npm run lint`, `npm run format:check`, `npm run typecheck`, and `npm test` before pushing.
+- Run `npm run check` before pushing.
 - Do not hand-edit `CHANGELOG.md` or `.release-please-manifest.json` - release-please owns them.
 - Human-authored PRs to `main` must go through [`no-mistakes`](https://github.com/kunchenguid/no-mistakes); CI enforces a deterministic signature in the PR body. See CONTRIBUTING.md.
 
@@ -51,7 +52,7 @@ When a session opens, `chokidar` watches the artifact's directory (excluding `.g
 
 ### AXI integration
 
-The CLI is built on `axi-sdk-js` (`runAxiCli`). The `home()` callback returns the rich object shown when the user runs `lavish-axi` with no arguments - this is the same TOON-serialized output that lands in the agent's `SessionStart` hook (`use_cases`, `artifact_guidance`, `visual_guidance`, `help`). The bare-arg form (`lavish-axi some.html`) is normalized into `["open", "some.html"]` by `normalizeArgv`.
+The CLI is built on `axi-sdk-js` (`runAxiCli`). The `home()` callback returns the rich object shown when the user runs `lavish-axi` with no arguments - this is the same TOON-serialized output that lands in the agent's `SessionStart` hook (`example_use_cases`, `artifact_guidance`, `visual_guidance`, `help`). The bare-arg form (`lavish-axi some.html`) is normalized into `["open", "some.html"]` by `normalizeArgv`.
 
 ### Telemetry
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
 
 - Node 22+, ESM-only JavaScript, and TypeScript `checkJs` validation.
 - Use TDD for bug fixes and new features.
-- Run `npm run lint`, `npm run format:check`, `npm run typecheck`, and `npm test` before pushing.
+- Run `npm run check` before pushing.
 - Do not hand-edit `CHANGELOG.md` or `.release-please-manifest.json`.
 - User-facing telemetry docs should stay minimal: anonymous usage telemetry, no sensitive content, and `LAVISH_AXI_TELEMETRY=0` opt-out.
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ npm link
 ## Development
 
 ```sh
+npm run check          # Run all verification commands
 npm run build          # Bundle the publishable CLI
 npm test               # Run node:test tests
 npm run lint           # Run ESLint

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   ],
   "scripts": {
     "build": "node scripts/build.js",
+    "check": "npm run build && npm run lint && npm run format:check && npm run typecheck && npm test",
     "start": "node dist/cli.mjs",
     "lint": "eslint bin src test scripts",
     "format": "prettier --write .",

--- a/src/cli.js
+++ b/src/cli.js
@@ -94,8 +94,9 @@ export function createHomeOutput({ bin, sessions }) {
       url: session.url,
       pending_prompts: session.pending_prompts || 0,
     })),
-    use_cases: [
-      "Implementation plans with diagrams, mockups, data flow, and code snippets",
+    example_use_cases: [
+      "Technical plans with diagrams, mockups, data flow, and code snippets",
+      "Brainstorming early ideas with recommendations, open questions, and visible tradeoffs",
       "Design explorations with multiple visual options side by side",
       "PR and code review explainers with annotated diffs and findings",
       "Interactive prototypes with sliders, knobs, forms, and animation tuning",
@@ -103,6 +104,7 @@ export function createHomeOutput({ bin, sessions }) {
       "Custom editing interfaces for triage, config editing, prompt tuning, dataset curation, and structured config editing",
     ],
     artifact_guidance: [
+      "Unless the user specifies another location, create HTML artifacts in the current working directory under `.lavish/`",
       "Use clear sections, headings, tabs, cards, tables, diagrams, and spatial layout instead of long prose",
       "Include concrete artifacts such as mockups, SVG diagrams, annotated code snippets, diffs, data-flow charts, and examples",
       "For exploration, show multiple options side by side and label the tradeoff each option makes",

--- a/test/cli-output.test.js
+++ b/test/cli-output.test.js
@@ -23,7 +23,10 @@ test("home output teaches agents when and how to use Lavish Editor", () => {
   assert.match(output.description, /Lavish Editor/);
   assert.match(output.description, /First generate an interactive HTML artifact/);
   assert.deepEqual(output.sessions, []);
-  assert.ok(output.use_cases.some((item) => item.includes("Implementation plans")));
+  assert.equal(output.use_cases, undefined);
+  assert.ok(output.example_use_cases.some((item) => item.includes("plans with diagrams")));
+  assert.ok(output.example_use_cases.some((item) => item.includes("Brainstorming early ideas")));
+  assert.ok(output.artifact_guidance.some((item) => item.includes("`.lavish/`")));
   assert.ok(output.artifact_guidance.some((item) => item.includes("window.lavish.queuePrompt")));
   assert.ok(output.visual_guidance.some((item) => item.includes("visual point of view")));
   assert.ok(output.help.some((item) => item.includes("lavish-axi <html-file>")));

--- a/test/package-json.test.js
+++ b/test/package-json.test.js
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("check script runs all verification commands", async () => {
+  const packageJson = JSON.parse(await readFile(new URL("../package.json", import.meta.url), "utf8"));
+  const checkCommands = packageJson.scripts.check.split(" && ");
+
+  assert.deepEqual(checkCommands, [
+    "npm run build",
+    "npm run lint",
+    "npm run format:check",
+    "npm run typecheck",
+    "npm test",
+  ]);
+});


### PR DESCRIPTION
## Intent

The developer wanted the CLI's no-argument AXI home output to better guide agents without implying a closed feature list. They asked to add guidance that, unless told otherwise, HTML artifacts should be created under a .lavish subdirectory in the current working directory, with the assistant choosing wording and placement. They also wanted an additional example use case for brainstorming early ideas with recommendations and open questions, and wanted the output key renamed from use_cases to example_use_cases so agents treat them as examples. Finally, they wanted a single npm run check command that runs the full verification suite.

## What Changed

- Renames the CLI home output `use_cases` field to `example_use_cases` and updates the examples with broader planning and brainstorming guidance.
- Adds artifact guidance telling agents to place generated HTML under `.lavish/` in the current working directory unless directed otherwise.
- Adds a consolidated `npm run check` script covering build, lint, format, typecheck, and tests, with documentation and package-json test coverage updated accordingly.

## Risk Assessment

✅ Low: The branch is limited to static CLI home guidance text, a renamed example key with focused tests, and an npm script addition, with no material correctness or runtime risks found.

## Testing

- Summary: Installed missing dependencies from the lockfile, then exercised the CLI home output tests, package script test, and full Node test suite; all relevant tests passed.
- `node --test test/cli-output.test.js`
- `node --test test/package-json.test.js`
- `npm test`
- Outcome: ✅ passed across 1 run (32.8s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `node --test test/cli-output.test.js`
- `node --test test/package-json.test.js`
- `npm test`

</details>

<details>
<summary>🔧 **Document** - 4 issues found → auto-fixed</summary>

**Round 1** - found 4 warnings
- ⚠️ `AGENTS.md:7` - The Commands section and project convention still list the individual verification commands but omit the newly added `npm run check` script that runs the full suite. Update this documentation so agents know to use the consolidated check command.
- ⚠️ `AGENTS.md:54` - The AXI integration docs still say the no-argument home output includes `use_cases`, but the code now emits `example_use_cases` instead. Update the documented output key to avoid stale schema guidance for agents.
- ⚠️ `README.md:113` - The Development command list documents build, test, lint, format, and typecheck separately but does not mention the new `npm run check` script that runs the complete verification suite. Add it to the development docs.
- ⚠️ `CONTRIBUTING.md:35` - The contributor convention still instructs contributors to run the individual verification commands before pushing instead of the new consolidated `npm run check` script. Update this guidance so it matches the package scripts.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
