### PR TITLE
ci: publish releases from release tags

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,6 +20,8 @@ jobs:
 
       - uses: actions/checkout@v6
         if: ${{ steps.release.outputs.release_created }}
+        with:
+          ref: ${{ steps.release.outputs.tag_name }}
 
       - uses: actions/setup-node@v6
         if: ${{ steps.release.outputs.release_created }}
@@ -51,3 +53,6 @@ jobs:
 
       - run: npm publish --access public --provenance
         if: ${{ steps.release.outputs.release_created }}
+        env:
+          LAVISH_AXI_UMAMI_HOST: https://a.kunchenguid.com
+          LAVISH_AXI_UMAMI_WEBSITE_ID: ${{ vars.LAVISH_AXI_UMAMI_WEBSITE_ID }}

--- a/test/package-json.test.js
+++ b/test/package-json.test.js
@@ -29,3 +29,21 @@ test("package lock root bin matches the publish manifest", async () => {
 
   assert.deepEqual(packageLock.packages[""].bin, packageJson.bin);
 });
+
+test("release workflow publishes from the release tag checkout", async () => {
+  const workflow = await readFile(new URL("../.github/workflows/release-please.yml", import.meta.url), "utf8");
+
+  assert.match(
+    workflow,
+    /uses: actions\/checkout@v6\n\s+if: \$\{\{ steps\.release\.outputs\.release_created \}\}\n\s+with:\n\s+ref: \$\{\{ steps\.release\.outputs\.tag_name \}\}/,
+  );
+});
+
+test("release workflow keeps telemetry env during npm publish prepack", async () => {
+  const workflow = await readFile(new URL("../.github/workflows/release-please.yml", import.meta.url), "utf8");
+
+  assert.match(
+    workflow,
+    /run: npm publish --access public --provenance\n\s+if: \$\{\{ steps\.release\.outputs\.release_created \}\}\n\s+env:\n\s+LAVISH_AXI_UMAMI_HOST: https:\/\/a\.kunchenguid\.com\n\s+LAVISH_AXI_UMAMI_WEBSITE_ID: \$\{\{ vars\.LAVISH_AXI_UMAMI_WEBSITE_ID \}\}/,
+  );
+});


### PR DESCRIPTION
## Intent

The developer wanted to fix why the globally installed lavish-axi CLI still reported version 0.1.0 even though npm latest was 0.1.3. They accepted the build-time inline approach, requiring the CLI version to come from package.json during the build rather than from a hardcoded constant or runtime-only filesystem read. They expected the fix to follow TDD and ensure the bundled CLI reports the package version after release.

## What Changed
- Updated the release-please workflow to check out the created release tag before running the publish job.
- Preserved the Umami telemetry build environment during `npm publish`, including the website ID from repository variables.
- Added package workflow tests covering the release tag checkout and publish-time telemetry environment.

## Risk Assessment

✅ Low: The changes are narrowly scoped to publishing from the release tag and preserving build-time telemetry env during prepack, with no material correctness or security issues found in the reviewed diff.

## Testing

- Summary: Exercised the release workflow assertions, CLI version/server behavior tests, and a built bundled CLI version check; all passed after installing lockfile dependencies.
- `node --test test/package-json.test.js`
- `node --test test/cli-output.test.js`
- `LAVISH_AXI_UMAMI_HOST=https://a.kunchenguid.com LAVISH_AXI_UMAMI_WEBSITE_ID=test-site npm run build && node dist/cli.mjs --version`
- Outcome: ✅ passed across 1 run (1m4s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `node --test test/package-json.test.js`
- `node --test test/cli-output.test.js`
- `LAVISH_AXI_UMAMI_HOST=https://a.kunchenguid.com LAVISH_AXI_UMAMI_WEBSITE_ID=test-site npm run build && node dist/cli.mjs --version`

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
