### PR TITLE
feat(cli): add artifact guidance playbooks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ Hand-edited files in `dist/` won't trigger reloads.
 
 ### AXI integration
 
-The CLI is built on `axi-sdk-js` (`runAxiCli`). The `home()` callback returns the rich object shown when the user runs `lavish-axi` with no arguments - this is the same TOON-serialized output that lands in the agent's `SessionStart` hook (`example_use_cases`, `artifact_guidance`, `visual_guidance`, `help`). The bare-arg form (`lavish-axi some.html`) is normalized into `["open", "some.html"]` by `normalizeArgv`.
+The CLI is built on `axi-sdk-js` (`runAxiCli`). The `home()` callback returns the rich object shown when the user runs `lavish-axi` with no arguments - this is the same TOON-serialized output that lands in the agent's `SessionStart` hook (`sessions`, `visual_guidance`, `playbooks`, `help`). Top-level `--help` returns the same static guidance without dynamic sessions, and `lavish-axi playbook [playbook_id]` exposes focused artifact guidance. The bare-arg form (`lavish-axi some.html`) is normalized into `["open", "some.html"]` by `normalizeArgv`.
 
 ### Telemetry
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ npm link
 | `lavish-axi <html-file>`      | Open or resume a Lavish Editor session.                      |
 | `lavish-axi poll <html-file>` | Long-poll until the user sends feedback or ends the session. |
 | `lavish-axi end <html-file>`  | End a session.                                               |
+| `lavish-axi playbook [id]`    | List focused artifact guidance or show one playbook.         |
+
+Known playbook IDs: `diagram`, `table`, `comparison`, `plan`, `diff`, `interactive`, `slides`.
 
 ### Flags
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -7,13 +7,14 @@ import { fileURLToPath } from "node:url";
 import { AxiError, runAxiCli } from "axi-sdk-js";
 
 import { defaultPort, ensureStateDir, stateFile } from "./paths.js";
+import { findPlaybook, listPlaybooks, playbookIds } from "./playbooks.js";
 import { serve } from "./server.js";
 import { canonicalFile, sessionKey, SessionStore } from "./session-store.js";
 import { initDefaultTelemetry } from "./telemetry.js";
 
-const COMMANDS = new Set(["open", "poll", "end", "server"]);
+const COMMANDS = new Set(["open", "poll", "end", "server", "playbook"]);
 const DESCRIPTION =
-  "Lavish Editor helps agents turn rich HTML artifacts into collaborative human review surfaces. First generate an interactive HTML artifact for the user to inspect, then run `lavish-axi <html-file>` so the user can visually review it, annotate elements or selected text, queue prompts, and send feedback back through `lavish-axi poll`.";
+  "Lavish Editor helps agents turn rich HTML artifacts into collaborative human review surfaces. First generate an interactive HTML artifact according to user request, then run `lavish-axi <html-file>` so the user can visually review it, annotate elements or selected text, queue prompts, and send feedback back through `lavish-axi poll`.";
 // Inlined at build time from package.json; falls back to reading package.json so source-run tests work.
 export const VERSION =
   process.env.LAVISH_AXI_BUILD_VERSION ||
@@ -22,6 +23,7 @@ export const VERSION =
 export async function run(argv) {
   await ensureStateDir();
   const normalizedArgv = normalizeArgv(argv);
+  const isTopLevelHelp = argv.length === 1 && argv[0] === "--help";
   const command = telemetryCommandName(argv);
   const telemetry = initDefaultTelemetry({
     app: "lavish-axi",
@@ -34,18 +36,20 @@ export async function run(argv) {
     await runAxiCli({
       description: DESCRIPTION,
       version: VERSION,
-      argv: normalizedArgv,
+      argv: isTopLevelHelp ? [] : normalizedArgv,
       topLevelHelp: TOP_LEVEL_HELP,
       hooks: { binaryNames: ["lavish-axi"] },
       home: async () =>
         createHomeOutput({
           bin: process.argv[1] || "lavish-axi",
-          sessions: await visibleSessions(),
+          sessions: isTopLevelHelp ? [] : await visibleSessions(),
+          includeSessions: !isTopLevelHelp,
         }),
       commands: {
         open: openCommand,
         poll: pollCommand,
         end: endCommand,
+        playbook: playbookCommand,
         server: serverCommand,
       },
       getCommandHelp,
@@ -88,49 +92,55 @@ export function telemetryCommandName(argv) {
   return normalized[0] && !normalized[0].startsWith("-") ? normalized[0] : "home";
 }
 
-export function createHomeOutput({ bin, sessions }) {
+export function createHomeOutput({ bin, sessions, includeSessions = true }) {
   return {
     bin: collapseHomeDirectory(bin, os.homedir()),
     description: DESCRIPTION,
-    sessions: sessions.map((session) => ({
-      file: session.file,
-      status: session.status,
-      url: session.url,
-      pending_prompts: session.pending_prompts || 0,
-    })),
-    example_use_cases: [
-      "Technical plans with diagrams, mockups, data flow, and code snippets",
-      "Brainstorming early ideas with recommendations, open questions, and visible tradeoffs",
-      "Design explorations with multiple visual options side by side",
-      "PR and code review explainers with annotated diffs and findings",
-      "Interactive prototypes with sliders, knobs, forms, and animation tuning",
-      "Reports, research summaries, incident writeups, and learning guides",
-      "Custom editing interfaces for triage, config editing, prompt tuning, dataset curation, and structured config editing",
-    ],
-    artifact_guidance: [
-      "Unless the user specifies another location, create HTML artifacts in the current working directory under `.lavish/`",
-      "Use clear sections, headings, tabs, cards, tables, diagrams, and spatial layout instead of long prose",
-      "Include concrete artifacts such as mockups, SVG diagrams, annotated code snippets, diffs, data-flow charts, and examples",
-      "For exploration, show multiple options side by side and label the tradeoff each option makes",
-      "For code review, render the relevant diff or snippets with inline annotations and severity-coded findings",
-      "For custom editors, include controls that let the user adjust values, then call `window.lavish.queuePrompt(...)` with the requested change",
-      "End interactive workflows with an obvious way for the user to queue prompts and send them back",
-    ],
+    ...(includeSessions
+      ? {
+          sessions: sessions.map((session) => ({
+            file: session.file,
+            status: session.status,
+            url: session.url,
+            pending_prompts: session.pending_prompts || 0,
+          })),
+        }
+      : {}),
     visual_guidance: [
-      "Choose a clear visual point of view that matches the artifact: editorial, technical dashboard, dense control room, refined memo, playful prototype, brutalist review board, etc.",
-      "Use typography, spacing, color, and layout deliberately; avoid generic system-font cards on white unless that restraint is the actual design choice",
       "Use visual hierarchy to make the most important decisions, risks, tradeoffs, and next actions obvious at a glance",
-      "Prefer diagrams, tables, annotated snippets, side-by-side comparisons, and spatial layouts over long prose",
-      "For explorations, make options visually distinct and label the tradeoff each option makes",
-      "For interactive artifacts, provide obvious controls and queue the user's chosen values with `window.lavish.queuePrompt(...)`",
+      "Use visual structure such as sections, cards, tables, diagrams, annotated snippets, and side-by-side comparisons instead of long prose",
+      "Choose typography, spacing, color, and layout deliberately so the artifact has a clear point of view",
       "Make the artifact responsive and readable; visual polish should improve comprehension, not distract from review",
     ],
+    playbooks: listPlaybooks(),
     help: [
       "Run `lavish-axi <html-file>` to open or resume a Lavish Editor session",
+      "Unless the user specifies another location, create HTML artifacts in the current working directory under `.lavish/`",
       "Run `lavish-axi poll <html-file>` to wait for user feedback",
       "Run `lavish-axi end <html-file>` to end a session",
+      "Run `lavish-axi playbook <playbook_id>` for focused artifact guidance",
+      "Use lavish-axi when the user asks for a visual artifact, HTML explainer, interactive prototype, review surface, technical plan, comparison, report, or browser-based feedback loop",
     ],
   };
+}
+
+export function createPlaybookOutput(args) {
+  const id = args[0];
+  if (!id) {
+    return {
+      playbooks: listPlaybooks(),
+      help: ["Run `lavish-axi playbook <playbook_id>` for focused artifact guidance"],
+    };
+  }
+
+  const playbook = findPlaybook(id);
+  if (!playbook) {
+    throw new AxiError(`Unknown playbook: ${id}`, "VALIDATION_ERROR", [
+      `Run \`lavish-axi playbook\` to list known IDs: ${playbookIds().join(", ")}`,
+    ]);
+  }
+
+  return { playbook };
 }
 
 export function createOpenOutput({ file, url, status }) {
@@ -213,6 +223,10 @@ async function endCommand(args) {
   const baseUrl = await ensureServer();
   const response = await postJson(`${baseUrl}/api/end`, { file: absolute });
   return { session: { file: absolute, status: response.status || "ended" } };
+}
+
+async function playbookCommand(args) {
+  return createPlaybookOutput(args);
 }
 
 async function serverCommand(args) {
@@ -412,11 +426,12 @@ export function getCommandHelp(command) {
   return COMMAND_HELP[command] || null;
 }
 
-const TOP_LEVEL_HELP = `lavish-axi - Lavish Editor AXI\n\nUsage:\n  lavish-axi\n  lavish-axi <html-file>\n  lavish-axi poll <html-file> [--agent-reply "..."]\n  lavish-axi end <html-file>\n\nNote: poll long-polls indefinitely by default until the user sends feedback or ends the session. Do not pass --timeout-ms during normal agent use; it is for tests and debugging only. do not set a short shell timeout; either run it without a timeout or use a very high threshold above 10 minutes.\n\n`;
+const TOP_LEVEL_HELP = `lavish-axi - Lavish Editor AXI\n\nUsage:\n  lavish-axi\n  lavish-axi <html-file>\n  lavish-axi poll <html-file> [--agent-reply "..."]\n  lavish-axi end <html-file>\n  lavish-axi playbook [playbook_id]\n\nNote: poll long-polls indefinitely by default until the user sends feedback or ends the session. Do not pass --timeout-ms during normal agent use; it is for tests and debugging only. do not set a short shell timeout; either run it without a timeout or use a very high threshold above 10 minutes.\n\n`;
 
 const COMMAND_HELP = {
   open: `Usage: lavish-axi <html-file> [--no-open]\n\nOpen or resume a Lavish Editor review session for an HTML artifact. Use --no-open when you need to ensure the server/session exists without opening another browser window.\n`,
   poll: `Usage: lavish-axi poll <html-file> [--agent-reply "..."]\n\nThis command long-polls indefinitely for queued user prompts, then returns them to the agent. Do not pass --timeout-ms during normal agent use; it is for tests and debugging only. do not set a short shell timeout; either run it without a timeout or use a very high threshold above 10 minutes so the user has time to review and send feedback. Use --agent-reply after applying prior feedback to display your response in Lavish Editor before waiting again.\n`,
   end: `Usage: lavish-axi end <html-file>\n\nEnd a Lavish Editor session.\n`,
+  playbook: `Usage: lavish-axi playbook [playbook_id]\n\nList focused artifact guidance playbooks, or show one playbook by ID. Known IDs: diagram, table, comparison, plan, diff, interactive, slides.\n\nExamples:\n  lavish-axi playbook\n  lavish-axi playbook diagram\n  lavish-axi playbook interactive\n`,
   server: `Usage: lavish-axi server [--port 4387]\n\nRun the local Lavish Editor server.\n`,
 };

--- a/src/playbooks.js
+++ b/src/playbooks.js
@@ -1,0 +1,211 @@
+export const PLAYBOOKS = [
+  {
+    id: "diagram",
+    use_when: "Map relationships, flows, state, and architecture",
+    choose: [
+      "Use Mermaid when automatic node placement and edge routing matter more than rich card content.",
+      "Use CSS grid, SVG, or positioned HTML when each item needs prose, code, controls, or detailed annotations.",
+      "Use a hybrid shape for large systems: a small overview diagram followed by detailed module cards.",
+    ],
+    structure: [
+      "Lead with the question the diagram answers, not with the implementation detail that produced it.",
+      "Keep the first visual to the core relationship, then put dense evidence or file references below it.",
+      "For complex systems, separate topology from detail so the overview stays readable.",
+    ],
+    design_rules: [
+      "Use page-scoped class names and avoid generic names like .node that can collide with diagram libraries.",
+      "Prefer top-down flow for multi-step diagrams unless the flow is genuinely linear and short.",
+      "Quote labels that contain punctuation or code-like names, and use explicit line breaks where the renderer supports them.",
+    ],
+    pitfalls: [
+      "Do not cram every file or function into one diagram when a layered explanation would be clearer.",
+      "Do not let default diagram colors clash with the page palette or dark mode.",
+      "Do not present unverified architecture claims as facts. Cite the files or commands that support them.",
+    ],
+    lavish_notes: [
+      "A Lavish diagram should invite precise annotation: make modules, edges, and captions easy to click and discuss.",
+      "When a relationship is uncertain, label it as a question so the user can resolve it in the review loop.",
+    ],
+  },
+  {
+    id: "table",
+    use_when: "Turn dense records into scan-friendly review surfaces",
+    choose: [
+      "Use a table when rows share the same fields and the user needs to compare evidence quickly.",
+      "Use cards when each record has a different shape or needs a long explanation.",
+      "Use summaries above the table when counts, risk levels, or statuses change how the table should be read.",
+    ],
+    structure: [
+      "Start with a short summary of what the rows prove or require.",
+      "Group columns by the decision they support: identity, evidence, status, action.",
+      "Keep raw details available, but make the primary status visible without reading every cell.",
+    ],
+    design_rules: [
+      "Use semantic table markup when the data is tabular.",
+      "Protect long paths, code symbols, URLs, and prose from overflowing on narrow screens.",
+      "Use restrained color for status and severity so the table remains readable when printed or skimmed.",
+    ],
+    pitfalls: [
+      "Do not paste a terminal table into HTML and call it done.",
+      "Do not hide the important conclusion below a large undifferentiated grid.",
+      "Do not use color as the only status signal.",
+    ],
+    lavish_notes: [
+      "A Lavish table should make individual rows easy annotation targets.",
+      "If a row implies a follow-up change, include an action control that queues a specific prompt.",
+    ],
+  },
+  {
+    id: "comparison",
+    use_when: "Show options, tradeoffs, and current vs target behavior",
+    choose: [
+      "Use before and after when the same system is changing over time.",
+      "Use option cards when the user needs to choose between mutually exclusive directions.",
+      "Use a scorecard only when the criteria are explicit and comparable.",
+    ],
+    structure: [
+      "Name the decision at the top of the artifact.",
+      "Show the concrete behavior or artifact shape for each side, not just abstract pros and cons.",
+      "End with a recommendation only when the evidence actually supports one.",
+    ],
+    design_rules: [
+      "Keep corresponding details aligned so differences are visible without hunting.",
+      "Use visual hierarchy to separate primary tradeoffs from secondary notes.",
+      "Make the cost of each option as visible as the benefit.",
+    ],
+    pitfalls: [
+      "Do not make every option look equally recommended if one is clearly preferred.",
+      "Do not compare vague summaries when concrete examples are available.",
+      "Do not bury assumptions that would change the recommendation.",
+    ],
+    lavish_notes: [
+      "A Lavish comparison should let the user annotate the exact option or tradeoff they want changed.",
+      "If the goal is selection, provide controls that queue the chosen option with rationale.",
+    ],
+  },
+  {
+    id: "plan",
+    use_when: "Explain a technical plan before implementation",
+    choose: [
+      "Use this when the user needs to inspect a feature approach before implementation begins.",
+      "Use it when state, APIs, files, tests, or edge cases are numerous enough to deserve a visual map.",
+      "Use a lighter comparison or diagram playbook when the plan is only a small design choice.",
+    ],
+    structure: [
+      "Start with the problem, the desired behavior, and what is out of scope.",
+      "Show affected state, commands, functions, files, and user-visible behavior.",
+      "Include edge cases and tests before implementation notes so risk is visible early.",
+    ],
+    design_rules: [
+      "Verify each claim against the codebase before presenting it as fact.",
+      "Keep code snippets focused on the pattern or seam, not full-file dumps.",
+      "Make test requirements concrete enough to drive TDD.",
+    ],
+    pitfalls: [
+      "Do not invent extension points or APIs that are not present in the repo.",
+      "Do not turn a plan into a long prose essay when state and file maps would be clearer.",
+      "Do not omit failure modes, migration concerns, or backwards compatibility questions.",
+    ],
+    lavish_notes: [
+      "A Lavish plan should make uncertainties easy to annotate before code exists.",
+      "Use controls for scope choices so the user can queue a precise implementation direction.",
+    ],
+  },
+  {
+    id: "diff",
+    use_when: "Present code or PR changes with evidence and findings",
+    choose: [
+      "Use this when the artifact is meant to help a human inspect a diff, PR, or local change set.",
+      "Use findings as the primary shape when bugs or regressions are possible.",
+      "Use architecture and file maps when the change is broad enough that text diffs lose the thread.",
+    ],
+    structure: [
+      "Start with the review scope and the most important findings.",
+      "Show changed areas, tests, docs implications, and any behavioral deltas.",
+      "Keep evidence close to each claim with file paths, line references, or command outputs.",
+    ],
+    design_rules: [
+      "Order findings by severity before summaries or praise.",
+      "Separate observed facts from inferred rationale.",
+      "Use severity, confidence, and affected file references consistently.",
+    ],
+    pitfalls: [
+      "Do not make a review artifact that is only a pretty changelog.",
+      "Do not state decision rationale as fact when it was inferred from code shape.",
+      "Do not skip tests and docs impact when public behavior changes.",
+    ],
+    lavish_notes: [
+      "A Lavish review should let the user click a finding and ask for the exact fix or clarification.",
+      "If no issue is found in a category, say so explicitly rather than leaving ambiguity.",
+    ],
+  },
+  {
+    id: "interactive",
+    use_when:
+      "Allow users to express preferences and choices through controls that send feedback from within the artifact",
+    choose: [
+      "Use this when the user needs to select, tune, triage, annotate, or edit a structured choice.",
+      "Use controls for decisions the user can make faster visually than by writing a prompt.",
+      "Use plain annotations when the artifact only needs open-ended feedback.",
+    ],
+    structure: [
+      "Make each decision surface visible: what is being chosen, what the options mean, and what happens next.",
+      "Pair controls with a readable summary of the prompt they will queue.",
+      "Show queued or selected state clearly so the user trusts what will be sent back.",
+    ],
+    design_rules: [
+      "Use window.lavish.queuePrompt(...) for explicit user requests from buttons, forms, and choice controls.",
+      "Make queued prompts specific enough that the agent can act without asking a follow-up question.",
+      "Keep native browser controls accessible and readable on mobile.",
+    ],
+    pitfalls: [
+      "Do not create controls whose queued prompt is unclear or too vague to execute.",
+      "Do not hide the fact that a click queues feedback for the agent.",
+      "Do not require interaction for content the user only needs to read.",
+    ],
+    lavish_notes: [
+      "Lavish is strongest when the artifact becomes a focused review surface and not just a static page.",
+      "End interactive paths with an obvious way for the user to send feedback back to the agent.",
+    ],
+  },
+  {
+    id: "slides",
+    use_when: "Create a deliberate presentation when slides are requested",
+    choose: [
+      "Use slides only when the user asks for a deck, presentation, talk, or paced walkthrough.",
+      "Use a scroll page when the user needs reference material, detailed review, or dense evidence.",
+      "Use one idea per slide when the artifact has a narrative arc.",
+    ],
+    structure: [
+      "Plan the story before writing the slide markup.",
+      "Open with the point, build context, show evidence, and close with the decision or next action.",
+      "Vary slide composition so the deck does not feel like repeated cards.",
+    ],
+    design_rules: [
+      "Keep slide text sparse and let visuals carry the explanation.",
+      "Use large type, strong alignment, and deliberate whitespace rather than dense paragraphs.",
+      "Make navigation and screen-size assumptions explicit in the artifact.",
+    ],
+    pitfalls: [
+      "Do not turn every explainer into slides by default.",
+      "Do not paste a scroll-page outline into fixed-size frames without rewriting the narrative.",
+      "Do not make consecutive slides with the same spatial composition unless repetition is the point.",
+    ],
+    lavish_notes: [
+      "A Lavish slide deck can still collect feedback, but each prompt should refer to a slide or decision.",
+      "Use slides for persuasion or presentation, not for dense code review.",
+    ],
+  },
+];
+
+export function listPlaybooks() {
+  return PLAYBOOKS.map(({ id, use_when }) => ({ id, use_when }));
+}
+
+export function findPlaybook(id) {
+  return PLAYBOOKS.find((playbook) => playbook.id === id) || null;
+}
+
+export function playbookIds() {
+  return PLAYBOOKS.map((playbook) => playbook.id);
+}

--- a/test/cli-output.test.js
+++ b/test/cli-output.test.js
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
-import { readFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import os from "node:os";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
@@ -12,6 +13,7 @@ import {
   createHomeOutput,
   createOpenOutput,
   createPollOutput,
+  createPlaybookOutput,
   createServerSpawnOptions,
   getCommandHelp,
   normalizeArgv,
@@ -35,13 +37,90 @@ test("home output teaches agents when and how to use Lavish Editor", () => {
   assert.match(output.description, /Lavish Editor/);
   assert.match(output.description, /First generate an interactive HTML artifact/);
   assert.deepEqual(output.sessions, []);
-  assert.equal(output.use_cases, undefined);
-  assert.ok(output.example_use_cases.some((item) => item.includes("plans with diagrams")));
-  assert.ok(output.example_use_cases.some((item) => item.includes("Brainstorming early ideas")));
-  assert.ok(output.artifact_guidance.some((item) => item.includes("`.lavish/`")));
-  assert.ok(output.artifact_guidance.some((item) => item.includes("window.lavish.queuePrompt")));
-  assert.ok(output.visual_guidance.some((item) => item.includes("visual point of view")));
+  assert.equal("use_cases" in output, false);
+  assert.equal("example_use_cases" in output, false);
+  assert.equal("artifact_guidance" in output, false);
+  assert.ok(output.visual_guidance.length <= 4);
+  assert.ok(output.visual_guidance.some((item) => item.includes("visual hierarchy")));
+  assert.ok(output.visual_guidance.some((item) => item.includes("sections, cards, tables")));
+  assert.ok(output.playbooks.some((item) => item.id === "diagram"));
+  assert.equal(
+    output.playbooks.find((item) => item.id === "interactive")?.use_when,
+    "Allow users to express preferences and choices through controls that send feedback from within the artifact",
+  );
   assert.ok(output.help.some((item) => item.includes("lavish-axi <html-file>")));
+  assert.ok(output.help.some((item) => item.includes("`.lavish/`")));
+  assert.ok(output.help.some((item) => item.includes("lavish-axi playbook <playbook_id>")));
+  assert.ok(!output.help.some((item) => item.includes("Known IDs")));
+  assert.ok(output.help.some((item) => item.includes("technical plan")));
+});
+
+test("top-level help renders static home output without dynamic sessions", async () => {
+  const stateDir = await mkdtemp(`${os.tmpdir()}/lavish-axi-help-test-`);
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [fileURLToPath(new URL("../bin/lavish-axi.js", import.meta.url)), "--help"],
+      {
+        cwd: fileURLToPath(new URL("..", import.meta.url)),
+        encoding: "utf8",
+        env: { ...process.env, LAVISH_AXI_STATE_DIR: stateDir },
+      },
+    );
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /playbooks\[7\]/);
+    assert.match(result.stdout, /lavish-axi playbook <playbook_id>/);
+    assert.doesNotMatch(result.stdout, /sessions\[/);
+    assert.doesNotMatch(result.stdout, /Known IDs/);
+  } finally {
+    await rm(stateDir, { force: true, recursive: true });
+  }
+});
+
+test("playbook index output lists known playbooks with concise descriptions", () => {
+  const output = createPlaybookOutput([]);
+
+  assert.equal(output.playbooks.length, 7);
+  assert.deepEqual(
+    output.playbooks.map((playbook) => playbook.id),
+    ["diagram", "table", "comparison", "plan", "diff", "interactive", "slides"],
+  );
+  assert.equal(
+    output.playbooks.find((playbook) => playbook.id === "plan")?.use_when,
+    "Explain a technical plan before implementation",
+  );
+  assert.equal(
+    output.playbooks.find((playbook) => playbook.id === "interactive")?.use_when,
+    "Allow users to express preferences and choices through controls that send feedback from within the artifact",
+  );
+  assert.ok(output.playbooks.every((playbook) => playbook.use_when.length > 20));
+  assert.ok(output.help.some((item) => item.includes("lavish-axi playbook <playbook_id>")));
+});
+
+test("playbook detail output returns focused Lavish-native guidance", () => {
+  const output = createPlaybookOutput(["interactive"]);
+
+  assert.equal(output.playbook.id, "interactive");
+  assert.match(output.playbook.use_when, /user/i);
+  assert.ok(output.playbook.choose.some((item) => item.includes("control")));
+  assert.ok(output.playbook.structure.some((item) => item.includes("decision")));
+  assert.ok(output.playbook.design_rules.some((item) => item.includes("queuePrompt")));
+  assert.ok(output.playbook.pitfalls.some((item) => item.includes("unclear")));
+  assert.ok(output.playbook.lavish_notes.some((item) => item.includes("Lavish")));
+});
+
+test("unknown playbook ids produce an actionable validation error", () => {
+  assert.throws(
+    () => createPlaybookOutput(["unknown"]),
+    (error) => {
+      assert.ok(error instanceof AxiError);
+      assert.equal(error.code, "VALIDATION_ERROR");
+      assert.match(error.message, /Unknown playbook/);
+      assert.ok(error.suggestions.some((item) => item.includes("lavish-axi playbook")));
+      return true;
+    },
+  );
 });
 
 test("home directory collapse tolerates Windows mixed separators", () => {
@@ -98,6 +177,7 @@ test("html file arguments normalize to the hidden open command", () => {
   assert.deepEqual(normalizeArgv(["report.html"]), ["open", "report.html"]);
   assert.deepEqual(normalizeArgv(["--no-open", "report.html"]), ["open", "--no-open", "report.html"]);
   assert.deepEqual(normalizeArgv(["poll", "report.html"]), ["poll", "report.html"]);
+  assert.deepEqual(normalizeArgv(["playbook", "diagram"]), ["playbook", "diagram"]);
   assert.deepEqual(normalizeArgv(["--help"]), ["--help"]);
 });
 
@@ -105,6 +185,7 @@ test("telemetry command names are anonymous and do not include file paths", () =
   assert.equal(telemetryCommandName(["report.html"]), "open");
   assert.equal(telemetryCommandName(["poll", "/tmp/secret/report.html"]), "poll");
   assert.equal(telemetryCommandName(["end", "/tmp/secret/report.html"]), "end");
+  assert.equal(telemetryCommandName(["playbook", "diagram"]), "playbook");
   assert.equal(telemetryCommandName([]), "home");
 });
 
@@ -168,6 +249,8 @@ test("open can resume a session without opening another browser window", () => {
   assert.equal(shouldOpenBrowser(["artifact.html"], { LAVISH_AXI_NO_OPEN: "1" }), false);
   assert.equal(shouldOpenBrowser(["artifact.html"], {}), true);
   assert.match(getCommandHelp("open"), /--no-open/);
+  assert.match(getCommandHelp("playbook"), /diagram/);
+  assert.match(getCommandHelp("playbook"), /interactive/);
 });
 
 test("polling a file without an active session tells the agent to open it first", () => {


### PR DESCRIPTION
## Intent

The developer wanted to add an opt-in playbook system to lavish-axi. They wanted a lavish-axi playbook <playbook_id> command with a known enum of Lavish-native playbooks for common HTML artifact primitives, plus compact discoverability in the home view. After iterating in Lavish Editor, they required the change to be additive, keep existing no-args guidance initially, use a JS registry, and treat the external repo as research material rather than copied source text. They then refined the default output: remove redundant playbook IDs from help, rename review to diff, update specific playbook descriptions, consolidate or remove artifact_guidance/example_use_cases, make --help show the same static home guidance without sessions, and move remaining artifact guidance into help or visual_guidance.

## What Changed

- Added a `lavish-axi playbook [playbook_id]` command backed by a JS playbook registry for listing and retrieving focused artifact guidance.
- Updated CLI home/help output to surface compact playbook discovery and reorganized artifact guidance under `visual_guidance`/`playbooks`.
- Added CLI output coverage for playbook listing, lookup, and unknown playbook handling, with README and agent docs updated for the new command and output shape.

## Risk Assessment

✅ Low: The change is additive and well-bounded to CLI guidance output, with the only identified issue being a low-impact maintainability drift risk.

## Testing

- Summary: Exercised the focused CLI output/playbook tests, direct playbook command paths including unknown-ID validation, and the full Node test suite; after installing missing dependencies, everything passed.
- `node --test test/cli-output.test.js`
- `node bin/lavish-axi.js playbook`
- `node bin/lavish-axi.js playbook interactive`
- `node bin/lavish-axi.js playbook unknown`
- `npm test`
- Outcome: ✅ passed across 1 run (1m58s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

**Round 1** - found 1 info
- ℹ️ `src/cli.js:435` - The playbook IDs in command help are hardcoded separately from the playbook registry, so future additions or renames can make `lavish-axi playbook --help` stale while `lavish-axi playbook` remains correct; derive this list from `playbookIds()` instead.

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `node --test test/cli-output.test.js`
- `node bin/lavish-axi.js playbook`
- `node bin/lavish-axi.js playbook interactive`
- `node bin/lavish-axi.js playbook unknown`
- `npm test`

</details>

<details>
<summary>🔧 **Document** - 2 issues found → auto-fixed</summary>

**Round 1** - found 2 warnings
- ⚠️ `README.md:104` - The CLI reference omits the new public `lavish-axi playbook [playbook_id]` command and its available playbook IDs, even though the change adds a user-facing command for listing and retrieving focused artifact guidance.
- ⚠️ `AGENTS.md:62` - The AXI integration notes still describe the home output as containing `example_use_cases` and `artifact_guidance`, but the change removes those fields and adds `playbooks`; this should be updated so agent-facing architecture docs match the current output shape.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
