### PR TITLE
feat: add input feedback controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,7 @@ No need to explicitly document the telemetry behaviors.
 
 - `canonicalFile` runs `realpath`, so symlinks resolve to their target before becoming session keys. Two paths that refer to the same file always collapse to one session.
 - The SDK injected into artifacts lives in `src/artifact-sdk.js` and is wrapped by `createSdkJs`. It executes inside an iframe sandboxed with `allow-scripts allow-forms allow-popups allow-downloads` (no `allow-same-origin`), so it cannot read the chrome's DOM - communication is `postMessage` only. Design asset injection is skipped when the HTML already contains `data-lavish-design` or opts out with `<meta name="lavish-design" content="off">`.
+- Artifact controls marked with `data-lavish-action` and their descendants are ignored by annotation handlers and get a pointer cursor, so use that marker on SDK-powered controls that call `window.lavish.queuePrompt()` or `window.lavish.sendQueuedPrompts()`.
 - For text annotations, `prompt.selector` is the common ancestor/container selector, not the complete identity. Use the `target` range boundaries and snapshot context to locate the exact selected text.
 - `SessionStore` re-reads and re-writes the entire `state.json` on every operation. There's no in-memory cache and no locking - acceptable because writes are infrequent and serialized through the single server process.
 - Tests use `LAVISH_AXI_STATE_DIR` and ephemeral ports to stay isolated. When adding tests that spin up the server, do the same.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ npm link
 | `lavish-axi playbook [id]`    | List focused artifact guidance or show one playbook.         |
 | `lavish-axi design`           | Show the injected Tailwind CSS and DaisyUI design reference. |
 
-Known playbook IDs: `diagram`, `table`, `comparison`, `plan`, `diff`, `interactive`, `slides`.
+Known playbook IDs: `diagram`, `table`, `comparison`, `plan`, `diff`, `input`, `slides`.
 
 ### Flags
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ npm link
 ```
 
 - **File-path identity** - Sessions are keyed by the canonical HTML file path, so agents do not need opaque IDs.
-- **Sandboxed artifact** - The artifact runs in an iframe while Lavish injects a small SDK for annotations and snapshots, plus Tailwind CSS v4 and DaisyUI v5 design assets unless the HTML includes `<meta name="lavish-design" content="off">`.
+- **Sandboxed artifact** - The artifact runs in an iframe while Lavish injects a small SDK for annotations, snapshots, and feedback controls, plus Tailwind CSS v4 and DaisyUI v5 design assets unless the HTML includes `<meta name="lavish-design" content="off">`.
+- **Feedback controls** - Mark buttons, choices, and other interactive elements with `data-lavish-action` so Lavish does not annotate them, then call `window.lavish.queuePrompt()` or `window.lavish.sendQueuedPrompts()` from the control handler.
 - **Precise targets** - Text annotations include selected text plus range anchors, so agents are not limited to whole-element selectors.
 - **Local-first state** - Session state stays under `.lavish-axi/` in the workspace.
 

--- a/src/artifact-sdk.js
+++ b/src/artifact-sdk.js
@@ -83,7 +83,7 @@ export function createArtifactSdk() {
     if (range.collapsed || !text) return null;
 
     const ancestor = closestElement(range.commonAncestorContainer);
-    if (isLavishUi(ancestor)) return null;
+    if (isLavishUi(ancestor) || isLavishAction(ancestor)) return null;
 
     const commonAncestorSelector = selector(ancestor);
     const target = {
@@ -108,6 +108,10 @@ export function createArtifactSdk() {
 
   function isLavishUi(el) {
     return !!(el && el.closest && el.closest("[data-lavish-ui]"));
+  }
+
+  function isLavishAction(el) {
+    return !!(el && el.closest && el.closest("[data-lavish-action]"));
   }
 
   function highlightElement(el) {
@@ -147,7 +151,7 @@ export function createArtifactSdk() {
       style = document.createElement("style");
       style.id = "lavish-cursor-style";
       style.textContent =
-        ":root{--lavish-accent:#f4c95d;--lavish-annotate-outline:2px solid var(--lavish-accent);--lavish-annotate-offset:2px}*{cursor:default!important}";
+        ":root{--lavish-accent:#f4c95d;--lavish-annotate-outline:2px solid var(--lavish-accent);--lavish-annotate-offset:2px}*{cursor:default!important}[data-lavish-action],[data-lavish-action] *{cursor:pointer!important}";
       document.head.appendChild(style);
     }
     if (!annotationMode && style) style.remove();
@@ -288,7 +292,7 @@ export function createArtifactSdk() {
   document.addEventListener(
     "mouseover",
     (event) => {
-      if (!annotationMode || isLavishUi(event.target)) return;
+      if (!annotationMode || isLavishUi(event.target) || isLavishAction(event.target)) return;
       if (event.target === selected) return;
       if (hovered && hovered !== selected) clearHighlight(hovered);
       hovered = event.target;
@@ -311,7 +315,7 @@ export function createArtifactSdk() {
   document.addEventListener(
     "mouseup",
     (event) => {
-      if (!annotationMode || isLavishUi(event.target)) return;
+      if (!annotationMode || isLavishUi(event.target) || isLavishAction(event.target)) return;
 
       const c = textSelectionContext(document.getSelection());
       if (!c) return;
@@ -325,7 +329,7 @@ export function createArtifactSdk() {
   document.addEventListener(
     "click",
     (event) => {
-      if (!annotationMode || isLavishUi(event.target)) return;
+      if (!annotationMode || isLavishUi(event.target) || isLavishAction(event.target)) return;
       event.preventDefault();
       event.stopPropagation();
       if (ignoreNextClick) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -113,7 +113,7 @@ export function createHomeOutput({ bin, sessions, includeSessions = true }) {
       "Use visual hierarchy to make the most important decisions, risks, tradeoffs, and next actions obvious at a glance",
       "Use visual structure such as sections, cards, tables, diagrams, annotated snippets, and side-by-side comparisons instead of long prose",
       "Choose typography, spacing, color, and layout deliberately so the artifact has a clear point of view",
-      "Make the artifact responsive and readable; visual polish should improve comprehension, not distract from review",
+      "Prevent horizontal overflow: design narrow layouts intentionally, use minmax(0, 1fr) and min-width: 0 for grid/flex children, and deliberately wrap or truncate long labels/status text",
     ],
     playbooks: listPlaybooks(),
     help: [
@@ -450,7 +450,7 @@ const COMMAND_HELP = {
   open: `Usage: lavish-axi <html-file> [--no-open]\n\nOpen or resume a Lavish Editor review session for an HTML artifact. Use --no-open when you need to ensure the server/session exists without opening another browser window.\n`,
   poll: `Usage: lavish-axi poll <html-file> [--agent-reply "..."]\n\nThis command long-polls indefinitely for queued user prompts, then returns them to the agent. Do not pass --timeout-ms during normal agent use; it is for tests and debugging only. do not set a short shell timeout; either run it without a timeout or use a very high threshold above 10 minutes so the user has time to review and send feedback. Use --agent-reply after applying prior feedback to display your response in Lavish Editor before waiting again.\n`,
   end: `Usage: lavish-axi end <html-file>\n\nEnd a Lavish Editor session.\n`,
-  playbook: `Usage: lavish-axi playbook [playbook_id]\n\nList focused artifact guidance playbooks, or show one playbook by ID. Known IDs: diagram, table, comparison, plan, diff, interactive, slides.\n\nExamples:\n  lavish-axi playbook\n  lavish-axi playbook diagram\n  lavish-axi playbook interactive\n`,
+  playbook: `Usage: lavish-axi playbook [playbook_id]\n\nList focused artifact guidance playbooks, or show one playbook by ID. Known IDs: diagram, table, comparison, plan, diff, input, slides.\n\nExamples:\n  lavish-axi playbook\n  lavish-axi playbook diagram\n  lavish-axi playbook input\n`,
   design: `Usage: lavish-axi design\n\nShow technical reference for the Tailwind CSS browser runtime v4, DaisyUI v5 components, and DaisyUI themes that Lavish auto-injects into artifacts. Do not add these libraries separately.\n`,
   server: `Usage: lavish-axi server [--port 4387]\n\nRun the local Lavish Editor server.\n`,
 };

--- a/src/playbooks.js
+++ b/src/playbooks.js
@@ -140,9 +140,9 @@ export const PLAYBOOKS = [
     ],
   },
   {
-    id: "interactive",
+    id: "input",
     use_when:
-      "Allow users to express preferences and choices through controls that send feedback from within the artifact",
+      "Must be used when the agent needs to collect user input on decisions, choices, preferences, triage, scope, or other structured feedback from within the artifact",
     choose: [
       "Use this when the user needs to select, tune, triage, annotate, or edit a structured choice.",
       "Use controls for decisions the user can make faster visually than by writing a prompt.",
@@ -154,7 +154,10 @@ export const PLAYBOOKS = [
       "Show queued or selected state clearly so the user trusts what will be sent back.",
     ],
     design_rules: [
-      "Use window.lavish.queuePrompt(...) for explicit user requests from buttons, forms, and choice controls.",
+      "Put data-lavish-action on any element that should act like a feedback control so Lavish does not annotate it and shows a pointer cursor instead.",
+      "Call window.lavish.queuePrompt(prompt, options) from the control's click, change, or submit handler to queue a precise request for the agent.",
+      "Pass options such as tag, text, selector, target, or data when they help the agent understand exactly what the user chose.",
+      "Call window.lavish.sendQueuedPrompts() when the control should immediately send the queued feedback instead of waiting for the user to press Send to Agent.",
       "Make queued prompts specific enough that the agent can act without asking a follow-up question.",
       "Keep native browser controls accessible and readable on mobile.",
     ],
@@ -165,7 +168,9 @@ export const PLAYBOOKS = [
     ],
     lavish_notes: [
       "Lavish is strongest when the artifact becomes a focused review surface and not just a static page.",
-      "End interactive paths with an obvious way for the user to send feedback back to the agent.",
+      "A minimal control looks like `<div role=\"button\" tabindex=\"0\" data-lavish-action onclick=\"window.lavish.queuePrompt('Choose option A', { tag: 'choice', text: 'Option A' })\">Choose option A</div>`.",
+      "Use window.lavish.queuePrompt for user intent, not internal analytics or UI-only state changes.",
+      "End input paths with an obvious way for the user to send feedback back to the agent.",
     ],
   },
   {

--- a/test/cli-output.test.js
+++ b/test/cli-output.test.js
@@ -45,10 +45,13 @@ test("home output teaches agents when and how to use Lavish Editor", () => {
   assert.ok(output.visual_guidance.length <= 4);
   assert.ok(output.visual_guidance.some((item) => item.includes("visual hierarchy")));
   assert.ok(output.visual_guidance.some((item) => item.includes("sections, cards, tables")));
+  assert.ok(output.visual_guidance.some((item) => item.includes("horizontal overflow")));
+  assert.ok(output.visual_guidance.some((item) => item.includes("minmax(0, 1fr)")));
+  assert.ok(!output.visual_guidance.some((item) => item.includes("test narrow viewports")));
   assert.ok(output.playbooks.some((item) => item.id === "diagram"));
   assert.equal(
-    output.playbooks.find((item) => item.id === "interactive")?.use_when,
-    "Allow users to express preferences and choices through controls that send feedback from within the artifact",
+    output.playbooks.find((item) => item.id === "input")?.use_when,
+    "Must be used when the agent needs to collect user input on decisions, choices, preferences, triage, scope, or other structured feedback from within the artifact",
   );
   assert.ok(output.help.some((item) => item.includes("lavish-axi <html-file>")));
   assert.ok(output.help.some((item) => item.includes("`.lavish/`")));
@@ -114,28 +117,31 @@ test("playbook index output lists known playbooks with concise descriptions", ()
   assert.equal(output.playbooks.length, 7);
   assert.deepEqual(
     output.playbooks.map((playbook) => playbook.id),
-    ["diagram", "table", "comparison", "plan", "diff", "interactive", "slides"],
+    ["diagram", "table", "comparison", "plan", "diff", "input", "slides"],
   );
   assert.equal(
     output.playbooks.find((playbook) => playbook.id === "plan")?.use_when,
     "Explain a technical plan before implementation",
   );
   assert.equal(
-    output.playbooks.find((playbook) => playbook.id === "interactive")?.use_when,
-    "Allow users to express preferences and choices through controls that send feedback from within the artifact",
+    output.playbooks.find((playbook) => playbook.id === "input")?.use_when,
+    "Must be used when the agent needs to collect user input on decisions, choices, preferences, triage, scope, or other structured feedback from within the artifact",
   );
   assert.ok(output.playbooks.every((playbook) => playbook.use_when.length > 20));
   assert.ok(output.help.some((item) => item.includes("lavish-axi playbook <playbook_id>")));
 });
 
 test("playbook detail output returns focused Lavish-native guidance", () => {
-  const output = createPlaybookOutput(["interactive"]);
+  const output = createPlaybookOutput(["input"]);
 
-  assert.equal(output.playbook.id, "interactive");
-  assert.match(output.playbook.use_when, /user/i);
+  assert.equal(output.playbook.id, "input");
+  assert.match(output.playbook.use_when, /Must be used/);
+  assert.match(output.playbook.use_when, /collect user input/);
   assert.ok(output.playbook.choose.some((item) => item.includes("control")));
   assert.ok(output.playbook.structure.some((item) => item.includes("decision")));
   assert.ok(output.playbook.design_rules.some((item) => item.includes("queuePrompt")));
+  assert.ok(output.playbook.design_rules.some((item) => item.includes("data-lavish-action")));
+  assert.ok(output.playbook.lavish_notes.some((item) => item.includes("window.lavish.queuePrompt")));
   assert.ok(output.playbook.pitfalls.some((item) => item.includes("unclear")));
   assert.ok(output.playbook.lavish_notes.some((item) => item.includes("Lavish")));
 });
@@ -295,7 +301,8 @@ test("open can resume a session without opening another browser window", () => {
   assert.equal(shouldOpenBrowser(["artifact.html"], {}), true);
   assert.match(getCommandHelp("open"), /--no-open/);
   assert.match(getCommandHelp("playbook"), /diagram/);
-  assert.match(getCommandHelp("playbook"), /interactive/);
+  assert.match(getCommandHelp("playbook"), /input/);
+  assert.doesNotMatch(getCommandHelp("playbook"), /interactive/);
   assert.match(getCommandHelp("design"), /DaisyUI/);
   assert.match(getCommandHelp("design"), /lavish-axi design/);
 });

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -138,6 +138,15 @@ test("annotation mode forces the artifact cursor to default", () => {
   assert.match(js, /setAnnotationMode\(enabled\)/);
 });
 
+test("artifact SDK lets marked feedback controls handle their own clicks", () => {
+  const js = createSdkJs("abc");
+
+  assert.match(js, /function isLavishAction/);
+  assert.match(js, /closest\(["']\[data-lavish-action\]["']\)/);
+  assert.match(js, /isLavishAction\(event\.target\)/);
+  assert.match(js, /\[data-lavish-action\],[^{}]*\[data-lavish-action\] \*\{cursor:pointer!important\}/);
+});
+
 test("turning annotation mode off clears selection and floating card", () => {
   const js = createSdkJs("abc");
 


### PR DESCRIPTION
## Intent

The developer wanted Lavish AXI to treat SDK-powered feedback controls as clickable input elements rather than annotation targets, using an explicit marker attribute that can be applied to any element, not just buttons. They requested renaming the interactive playbook to input, strengthening its guidance so agents must use it when collecting user decisions or choices, and documenting detailed SDK usage around the marker and queuePrompt. They then asked to review the changes with the locally built CLI using the newly updated input controls. After noticing a responsive overflow issue in a review artifact, they wanted to understand the root cause and prevent similar mistakes through general agent-facing guidance, but explicitly did not want guidance that prescribes testing narrow viewports because testing can consume tokens and should be left to the agent’s judgment.

## What Changed

- Added `data-lavish-action` handling so SDK-powered controls and their descendants are treated as clickable feedback inputs instead of annotation targets.
- Renamed the feedback-control playbook from `interactive` to `input` and updated CLI/playbook output guidance for collecting user choices with `window.lavish.queuePrompt()` and `sendQueuedPrompts()`.
- Updated README, AGENTS guidance, and CLI/server tests to cover the new input-control contract.

## Risk Assessment

✅ Low: The change is narrowly scoped to playbook naming/guidance and SDK click/selection suppression for explicitly marked feedback controls, with no material risks found in the reviewed diff.

## Testing

- Summary: After installing missing dependencies, I exercised the SDK/action-marker and playbook/CLI-output coverage plus the full Node test suite, and all tests passed.
- `node --test test/server.test.js test/cli-output.test.js`
- `npm test`
- Outcome: ✅ passed across 1 run (1m44s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 warning
- ⚠️ `README.md:113` - The public CLI reference still advertises `interactive` as a known playbook ID, but the branch renamed that ID to `input`; users following the README will now get `Unknown playbook: interactive` instead of the intended guidance.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `node --test test/server.test.js test/cli-output.test.js`
- `npm test`

</details>

<details>
<summary>🔧 **Document** - 2 issues found → auto-fixed</summary>

**Round 1** - found 2 issues (1 warning, 1 info)
- ⚠️ `README.md:98` - The README describes the injected SDK only as supporting annotations and snapshots, but this change adds a public artifact-authoring behavior: elements marked with data-lavish-action are excluded from annotation handling and can use window.lavish.queuePrompt()/sendQueuedPrompts() as feedback controls. The published README should document the marker attribute and the basic SDK usage so users can discover the new input-control capability without relying only on dynamic playbook output.
- ℹ️ `AGENTS.md:76` - The repository architecture notes for the injected artifact SDK omit the new data-lavish-action contract. Since the SDK now treats marked elements and their descendants as clickable feedback controls rather than annotation targets, the developer-facing notes should mention this behavior alongside the existing sandbox and design-injection details.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
