### PR TITLE
Support remote Lavish review URLs

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -155,13 +155,16 @@ export function createOpenOutput({ file, url, status }) {
 }
 
 async function openCommand(args) {
-  const file = args.find((arg) => !arg.startsWith("-"));
+  const file = htmlFileArg(args);
   if (!file) {
     throw new AxiError("HTML file path is required", "VALIDATION_ERROR", ["Run `lavish-axi <html-file>`"]);
   }
   await assertHtmlFile(file);
   const absolute = await canonicalFile(file);
-  const baseUrl = await ensureServer({ forceRestart: shouldForceRestartForLocalBuild(process.argv[1] || "") });
+  const baseUrl = await ensureServer({
+    args,
+    forceRestart: shouldForceRestartForLocalBuild(process.argv[1] || ""),
+  });
   const response = await postJson(`${baseUrl}/api/sessions`, { file: absolute });
   if (shouldOpenBrowser(args, process.env)) {
     try {
@@ -239,7 +242,9 @@ async function designCommand() {
 
 async function serverCommand(args) {
   const port = Number(flagValue(args, "--port") || defaultPort());
-  const server = await serve({ port, stateFile: stateFile(), version: VERSION });
+  const host = resolveBindHost({ args, env: process.env });
+  const publicBaseUrl = resolvePublicBaseUrl({ args, env: process.env, port });
+  const server = await serve({ port, host, stateFile: stateFile(), version: VERSION, publicBaseUrl });
   await server.done;
   return "";
 }
@@ -266,9 +271,11 @@ function isHtmlPath(file) {
   return file.toLowerCase().endsWith(".html") || file.toLowerCase().endsWith(".htm");
 }
 
-async function ensureServer({ forceRestart = false } = {}) {
+async function ensureServer({ args = [], forceRestart = false } = {}) {
   const port = defaultPort();
-  const baseUrl = `http://localhost:${port}`;
+  const host = resolveBindHost({ args, env: process.env });
+  const publicBaseUrl = resolvePublicBaseUrl({ args, env: process.env, port });
+  const baseUrl = `http://${controlHost(host)}:${port}`;
   const existing = await fetchHealth(baseUrl);
   if (existing && !shouldRestartServer(VERSION, existing, forceRestart)) {
     return baseUrl;
@@ -288,7 +295,7 @@ async function ensureServer({ forceRestart = false } = {}) {
       }
     }
   }
-  await startServer(port);
+  await startServer(port, { host, publicBaseUrl });
   const deadline = Date.now() + 5000;
   while (Date.now() < deadline) {
     const health = await fetchHealth(baseUrl);
@@ -379,13 +386,19 @@ function killProcessOnPort(port) {
   }
 }
 
-async function startServer(port) {
+async function startServer(port, options = { host: null, publicBaseUrl: null }) {
+  const { host, publicBaseUrl } = options;
   await ensureStateDir();
   const entry = resolveServerEntry();
   const child = spawn(process.execPath, [entry, "server", "--port", String(port)], {
     detached: true,
     stdio: "ignore",
-    env: { ...process.env, LAVISH_AXI_NO_OPEN: "1" },
+    env: {
+      ...process.env,
+      LAVISH_AXI_NO_OPEN: "1",
+      LAVISH_AXI_HOST: host || resolveBindHost({ env: process.env }),
+      LAVISH_AXI_PUBLIC_URL: publicBaseUrl || resolvePublicBaseUrl({ env: process.env, port }),
+    },
   });
   child.unref();
 }
@@ -436,6 +449,37 @@ function flagValue(args, flag) {
   return args[index + 1] || null;
 }
 
+export function resolveBindHost({ args = [], env = process.env } = {}) {
+  return String(flagValue(args, "--host") || env.LAVISH_AXI_HOST || "127.0.0.1").trim() || "127.0.0.1";
+}
+
+export function resolvePublicBaseUrl({ args = [], env = process.env, port = defaultPort() } = {}) {
+  const explicit = flagValue(args, "--public-url") || env.LAVISH_AXI_PUBLIC_URL;
+  return normalizeBaseUrl(explicit || `http://localhost:${port}`);
+}
+
+function normalizeBaseUrl(url) {
+  return String(url || "")
+    .trim()
+    .replace(/\/+$/, "");
+}
+
+function controlHost(host) {
+  return host === "0.0.0.0" || host === "::" ? "localhost" : host;
+}
+
+function htmlFileArg(args) {
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg.startsWith("-")) {
+      if (["--host", "--public-url", "--port"].includes(arg)) i += 1;
+      continue;
+    }
+    if (isHtmlPath(arg)) return arg;
+  }
+  return null;
+}
+
 function delay(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -444,15 +488,15 @@ export function getCommandHelp(command) {
   return COMMAND_HELP[command] || null;
 }
 
-const TOP_LEVEL_HELP = `lavish-axi - Lavish Editor AXI\n\nUsage:\n  lavish-axi\n  lavish-axi <html-file>\n  lavish-axi poll <html-file> [--agent-reply "..."]\n  lavish-axi end <html-file>\n  lavish-axi playbook [playbook_id]\n  lavish-axi design\n\n${DESIGN_SYSTEM_HINT}\n\nNote: poll long-polls indefinitely by default until the user sends feedback or ends the session. Do not pass --timeout-ms during normal agent use; it is for tests and debugging only. do not set a short shell timeout; either run it without a timeout or use a very high threshold above 10 minutes.\n\n`;
+const TOP_LEVEL_HELP = `lavish-axi - Lavish Editor AXI\n\nUsage:\n  lavish-axi\n  lavish-axi <html-file> [--host <address>] [--public-url <url>]\n  lavish-axi poll <html-file> [--agent-reply "..."]\n  lavish-axi end <html-file>\n  lavish-axi playbook [playbook_id]\n  lavish-axi design\n\n${DESIGN_SYSTEM_HINT}\n\nNote: poll long-polls indefinitely by default until the user sends feedback or ends the session. Do not pass --timeout-ms during normal agent use; it is for tests and debugging only. do not set a short shell timeout; either run it without a timeout or use a very high threshold above 10 minutes.\n\n`;
 
 const COMMAND_HELP = {
-  open: `Usage: lavish-axi <html-file> [--no-open]\n\nOpen or resume a Lavish Editor review session for an HTML artifact. Use --no-open when you need to ensure the server/session exists without opening another browser window.\n`,
+  open: `Usage: lavish-axi <html-file> [--no-open] [--host <address>] [--public-url <url>]\n\nOpen or resume a Lavish Editor review session for an HTML artifact. Use --no-open when you need to ensure the server/session exists without opening another browser window. Use --host or LAVISH_AXI_HOST to bind the server to an explicit interface such as a Tailscale IP. Use --public-url or LAVISH_AXI_PUBLIC_URL to advertise the URL the reviewer should open. Defaults stay loopback-only.\n`,
   poll: `Usage: lavish-axi poll <html-file> [--agent-reply "..."]\n\nThis command long-polls indefinitely for queued user prompts, then returns them to the agent. Do not pass --timeout-ms during normal agent use; it is for tests and debugging only. do not set a short shell timeout; either run it without a timeout or use a very high threshold above 10 minutes so the user has time to review and send feedback. Use --agent-reply after applying prior feedback to display your response in Lavish Editor before waiting again.\n`,
   end: `Usage: lavish-axi end <html-file>\n\nEnd a Lavish Editor session.\n`,
   playbook: `Usage: lavish-axi playbook [playbook_id]\n\nList focused artifact guidance playbooks, or show one playbook by ID. Known IDs: diagram, table, comparison, plan, diff, input, slides.\n\nExamples:\n  lavish-axi playbook\n  lavish-axi playbook diagram\n  lavish-axi playbook input\n`,
   design: `Usage: lavish-axi design\n\nShow technical reference for the Tailwind CSS browser runtime v4, DaisyUI v5 components, and DaisyUI themes that Lavish auto-injects into artifacts. Do not add these libraries separately.\n`,
-  server: `Usage: lavish-axi server [--port 4387]\n\nRun the local Lavish Editor server.\n`,
+  server: `Usage: lavish-axi server [--port 4387] [--host 127.0.0.1] [--public-url <url>]\n\nRun the local Lavish Editor server. Defaults bind to 127.0.0.1 and advertise http://localhost:<port>. Use --host and --public-url for remote review over a private interface such as Tailscale.\n`,
 };
 
 export { createDesignOutput };

--- a/src/server.js
+++ b/src/server.js
@@ -29,13 +29,14 @@ const designAssetUrls = {
   },
 };
 
-export async function serve({ port, stateFile, version = "" }) {
+export async function serve({ port, host = "127.0.0.1", stateFile, version = "", publicBaseUrl = null }) {
   const app = express();
   const store = new SessionStore(stateFile);
   const events = new EventEmitter();
   const watchers = new Map();
   const activePolls = new Map();
   const sseClients = new Set();
+  const advertisedBaseUrl = normalizeBaseUrl(publicBaseUrl || `http://localhost:${port}`);
 
   app.use(express.json({ limit: "2mb" }));
 
@@ -58,7 +59,7 @@ export async function serve({ port, stateFile, version = "" }) {
     try {
       const file = await canonicalFile(req.body.file);
       const key = sessionKey(file);
-      const url = `http://localhost:${port}/session/${key}`;
+      const url = `${advertisedBaseUrl}/session/${key}`;
       const session = await store.upsertSession(file, url);
       watchSession(session, watchers, events);
       res.json({ key, file, url, status: "opened" });
@@ -293,7 +294,7 @@ export async function serve({ port, stateFile, version = "" }) {
   });
 
   const httpServer = await new Promise((resolve) => {
-    const s = app.listen(port, "127.0.0.1", () => resolve(s));
+    const s = app.listen(port, host, () => resolve(s));
   });
 
   let shuttingDown = false;
@@ -331,6 +332,10 @@ export async function serve({ port, stateFile, version = "" }) {
     },
     done,
   };
+}
+
+function normalizeBaseUrl(url) {
+  return String(url || "").replace(/\/+$/, "");
 }
 
 async function readDesignAsset(asset) {

--- a/src/telemetry.js
+++ b/src/telemetry.js
@@ -111,7 +111,7 @@ class HttpTelemetryClient {
     await Promise.race([
       drained,
       new Promise((resolve) => {
-        setTimeout(resolve, timeoutMs).unref?.();
+        setTimeout(resolve, timeoutMs);
       }),
     ]);
   }

--- a/test/cli-output.test.js
+++ b/test/cli-output.test.js
@@ -18,6 +18,8 @@ import {
   createServerSpawnOptions,
   getCommandHelp,
   normalizeArgv,
+  resolveBindHost,
+  resolvePublicBaseUrl,
   resolveServerEntry,
   shouldForceRestartForLocalBuild,
   shouldKillProcessOnPort,
@@ -232,6 +234,32 @@ test("server spawn options detach without inheriting invalid streams", () => {
 
   assert.equal(options.detached, true);
   assert.equal(options.stdio, "ignore");
+});
+
+test("remote server config defaults to loopback and localhost public URLs", () => {
+  assert.equal(resolveBindHost({ env: {} }), "127.0.0.1");
+  assert.equal(resolvePublicBaseUrl({ env: {}, port: 4387 }), "http://localhost:4387");
+});
+
+test("remote server config supports explicit bind host and public URL", () => {
+  assert.equal(resolveBindHost({ args: ["--host", "100.76.128.114"], env: {} }), "100.76.128.114");
+  assert.equal(resolveBindHost({ args: [], env: { LAVISH_AXI_HOST: "100.76.128.114" } }), "100.76.128.114");
+  assert.equal(
+    resolvePublicBaseUrl({
+      args: ["--public-url", "http://100.76.128.114:4387"],
+      env: {},
+      port: 4387,
+    }),
+    "http://100.76.128.114:4387",
+  );
+  assert.equal(
+    resolvePublicBaseUrl({
+      args: [],
+      env: { LAVISH_AXI_PUBLIC_URL: "http://100.76.128.114:4387/" },
+      port: 4387,
+    }),
+    "http://100.76.128.114:4387",
+  );
 });
 
 test("server entry resolves to a node-executable script that actually invokes run()", () => {

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -437,6 +437,33 @@ test("/health reports the server version so clients can detect upgrades", async 
     const body = await res.json();
     assert.equal(body.ok, true);
     assert.equal(body.version, "9.9.9-test");
+  } finally {
+    await server.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("session URLs use configured public base URL", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "lavish-serve-"));
+  const artifact = path.join(dir, "artifact.html");
+  await writeFile(artifact, "<!doctype html><title>remote</title>");
+  const server = await serve({
+    port: 0,
+    stateFile: path.join(dir, "state.json"),
+    version: "9.9.9-test",
+    publicBaseUrl: "http://100.76.128.114:4387/",
+  });
+  try {
+    const res = await fetch(`http://127.0.0.1:${server.port}/api/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ file: artifact }),
+    });
+    const body = await res.json();
+
+    assert.equal(res.status, 200);
+    assert.match(body.url, /^http:\/\/100\.76\.128\.114:4387\/session\//);
+    assert.doesNotMatch(body.url, /localhost/);
   } finally {
     await server.close();
     await rm(dir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Adds minimal remote-collaboration support while keeping the default local-only behavior unchanged:

- `--host <address>` / `LAVISH_AXI_HOST` lets the server bind to an explicit interface, e.g. a Tailscale IP.
- `--public-url <url>` / `LAVISH_AXI_PUBLIC_URL` controls the session URL returned to the agent/user.
- Defaults remain safe and local: bind `127.0.0.1`, advertise `http://localhost:<port>`.
- Help text documents the remote options.

This enables the common workflow where the agent runs Lavish on a VPS and the human opens the editor from their own machine over a private network.

## Example

```sh
lavish-axi report.html \
  --host 100.76.128.114 \
  --public-url http://100.76.128.114:4387
```

The returned `session.url` then points at the reachable private-network URL instead of localhost.

## Tests

- `node --test --test-name-pattern "remote server config|session URLs use configured public base URL|telemetry close waits" test/cli-output.test.js test/server.test.js test/telemetry.test.js`
- `npm run check`
- Manual smoke:
  - `node bin/lavish-axi.js artifact.html --no-open --host 127.0.0.1 --public-url http://100.76.128.114:<port>`
  - verified output advertised the configured public URL

## Notes

I also adjusted telemetry close timeout handling so the existing Node 22 test completes reliably; the previous unref'd timeout could leave the close race unresolved when the mocked drain never completes.
