### PR TITLE
feat: add HtmlShip artifact sharing

### DIFF
--- a/.agents/skills/lavish-design/ui_kits/editor/README.md
+++ b/.agents/skills/lavish-design/ui_kits/editor/README.md
@@ -1,6 +1,7 @@
 # Lavish Editor — UI kit
 
-A high-fidelity, clickable recreation of the **Lavish Editor chrome** that the `lavish-axi` CLI launches in a browser. Every styling value (colors, radii, shadows, spacing, type) is pulled either directly from `src/chrome.css` and `src/artifact-sdk.js` in the [`kunchenguid/lavish-axi`](https://github.com/kunchenguid/lavish-axi) repo or from `colors_and_type.css` in the parent of this folder.
+A high-fidelity, clickable recreation of the **Lavish Editor chrome** that the `lavish-axi` CLI launches in a browser, except for server-backed flows called out below.
+Every styling value (colors, radii, shadows, spacing, type) is pulled either directly from `src/chrome.css` and `src/artifact-sdk.js` in the [`kunchenguid/lavish-axi`](https://github.com/kunchenguid/lavish-axi) repo or from `colors_and_type.css` in the parent of this folder.
 
 Open `index.html` and try:
 
@@ -17,7 +18,7 @@ Everything is fake — there's no `lavish-axi` server backing it. The reply text
 
 - `index.html` — entry; pulls React, Babel, and every JSX file in order.
 - `app.jsx` — top-level `App` component. Holds chat / queued-prompts / annotation state.
-- `TopBar.jsx` — the 56px sticky bar (brand · file path · Annotation toggle · End Session).
+- `TopBar.jsx` — the 56px sticky bar (brand · file path · Annotation toggle · End Session); the product's HtmlShip Share control is intentionally omitted.
 - `Artifact.jsx` — the faux landing page rendered where the agent's HTML normally goes.
 - `AnnotationCard.jsx` — floating card that opens when an element is clicked.
 - `ChatPanel.jsx` — side panel: heading + chat log + composer.
@@ -33,5 +34,6 @@ This is a **kit**, not a build of the product. Skipped:
 - The `EventSource` reload pipe, the `chokidar` watcher.
 - DOM snapshot serialization. `lavish.snapshot()` would produce something like the tree in `src/artifact-sdk.js`; we don't.
 - File-path identity, session store, long-polling.
+- HtmlShip sharing. The product top bar includes a Share button and dialog that publishes the current HTML file, but this static kit does not call the share API.
 
 Read `src/server.js`, `src/chrome-client.js`, `src/chrome.css`, and `src/artifact-sdk.js` in the lavish-axi repo for the canonical behaviour.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,9 +46,15 @@ State lives at `~/.lavish-axi/state.json` (override with `LAVISH_AXI_STATE_DIR`)
    The chrome client reads its session bootstrap from the `lavish-session` JSON script in the page.
 3. The artifact route reads the HTML from disk and runs `injectLavishSdk` (`src/html-transform.js`) to append `<script src="/sdk.js?key=...">` and, unless the artifact opts out with `<meta name="lavish-design" content="off">`, inject `/design/daisyui.css`, `/design/tailwindcss-browser.js`, and `/design/daisyui-themes.css`.
 4. Sibling assets resolve under `/artifact/:key/<path>`, sandboxed to the artifact's directory (`resolveArtifactAsset` rejects paths that escape via `..`), while packaged Tailwind/DaisyUI assets are served from `/design/:asset`.
-5. User actions in the iframe `postMessage` to the chrome (queue prompts, request snapshot, end session). The chrome POSTs collected prompts to `/api/:key/prompts`, which queues them in the session store and emits a `feedback` event. Text selection prompts use `tag: "text"` and preserve a structured `target` with `type: "text-range"`, selected text, `commonAncestorSelector`, and start/end boundary anchors.
-6. `lavish-axi poll <file.html>` (`pollCommand`) hits `GET /api/poll`. If queued prompts exist, it returns immediately; otherwise it long-polls on an `EventEmitter` until a `feedback` or `ended` event fires (default: no timeout - `--timeout-ms` is a test escape hatch).
-7. `--agent-reply` posts a chat message into the session before polling, so the agent's reply renders in the browser conversation panel via the `/events/:key` SSE stream.
+5. The chrome Share dialog POSTs `/api/:key/share` with title, password, expiration, parent slug, and sandbox mode after a same-origin check. The server reads the source HTML, runs `injectPublicDesignAssets` to use CDN Tailwind/DaisyUI links without the annotation SDK, calls HtmlShip `/api/v1/pages` through `publishHtmlShipPage`, and returns the share URL plus owner key.
+6. User actions in the iframe `postMessage` to the chrome (queue prompts, request snapshot, end session). The chrome POSTs collected prompts to `/api/:key/prompts`, which queues them in the session store and emits a `feedback` event. Text selection prompts use `tag: "text"` and preserve a structured `target` with `type: "text-range"`, selected text, `commonAncestorSelector`, and start/end boundary anchors.
+7. `lavish-axi poll <file.html>` (`pollCommand`) hits `GET /api/poll`. If queued prompts exist, it returns immediately; otherwise it long-polls on an `EventEmitter` until a `feedback` or `ended` event fires (default: no timeout - `--timeout-ms` is a test escape hatch).
+8. `--agent-reply` posts a chat message into the session before polling, so the agent's reply renders in the browser conversation panel via the `/events/:key` SSE stream.
+
+### HtmlShip sharing
+
+Sharing uses `HTMLSHIP_API_URL` when set, otherwise `https://api.htmlship.com`.
+Set `HTMLSHIP_API_KEY` to send `Authorization: Bearer <key>` with publish requests.
 
 ### Live reload
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ That loses the thing HTML is best at: interactivity.
 
 Lavish Editor opens agent-generated HTML files in a local browser, lets you pinpoint elements or selected text and send feedback to the agent to address.
 
-- **Local only** - Work with your local HTML artifacts with a local CLI. Zero cloud dependency.
+- **Local-first** - Work with local HTML artifacts through a local CLI; publishing to HtmlShip is optional when you need a share URL.
 - **Human-AI collaboration** - Annotate elements, selected text ranges, and send messages to the agent without leaving Lavish Editor.
 - **Battery included** - Lavish Editor teaches your agent good visualization for common use cases such as technial plans, design explorations and more out of the box.
 
@@ -96,6 +96,9 @@ pnpm link
 
 - **File-path identity** - Sessions are keyed by the canonical HTML file path, so agents do not need opaque IDs.
 - **Sandboxed artifact** - The artifact runs in an iframe while Lavish injects a small SDK for annotations, snapshots, and feedback controls, plus Tailwind CSS v4 and DaisyUI v5 design assets unless the HTML includes `<meta name="lavish-design" content="off">`.
+- **Optional sharing** - The browser Share button can publish the current HTML file to HtmlShip, with optional password and expiration controls.
+  Local review stays local unless you publish.
+  Shared pages rewrite Lavish design assets to public CDN URLs, omit the annotation SDK, and may not resolve local sibling assets.
 - **Feedback controls** - Mark buttons, choices, and other interactive elements with `data-lavish-action` so Lavish does not annotate them, then call `window.lavish.queuePrompt()` or `window.lavish.sendQueuedPrompts()` from the control handler.
 - **Precise targets** - Text annotations include selected text plus range anchors, so agents are not limited to whole-element selectors.
 - **Local-first state** - Session state stays under `.lavish-axi/` in the workspace.

--- a/src/chrome-client.js
+++ b/src/chrome-client.js
@@ -14,6 +14,23 @@ const annotationButton = /** @type {HTMLButtonElement} */ (document.getElementBy
 const endButton = /** @type {HTMLButtonElement} */ (document.getElementById("end"));
 const filePathInput = /** @type {HTMLInputElement} */ (document.getElementById("filePath"));
 const copyPathButton = /** @type {HTMLButtonElement} */ (document.getElementById("copyPath"));
+const shareButton = /** @type {HTMLButtonElement} */ (document.getElementById("share"));
+const shareDialog = /** @type {HTMLDivElement} */ (document.getElementById("shareDialog"));
+const shareForm = /** @type {HTMLFormElement} */ (document.getElementById("shareForm"));
+const shareCloseButton = /** @type {HTMLButtonElement} */ (document.getElementById("shareClose"));
+const shareCancelButton = /** @type {HTMLButtonElement} */ (document.getElementById("shareCancel"));
+const sharePublishButton = /** @type {HTMLButtonElement} */ (document.getElementById("sharePublish"));
+const shareTitleInput = /** @type {HTMLInputElement} */ (document.getElementById("shareTitle"));
+const sharePasswordInput = /** @type {HTMLInputElement} */ (document.getElementById("sharePassword"));
+const shareExpiresInInput = /** @type {HTMLInputElement} */ (document.getElementById("shareExpiresIn"));
+const shareParentSlugInput = /** @type {HTMLInputElement} */ (document.getElementById("shareParentSlug"));
+const shareSandboxModeInput = /** @type {HTMLSelectElement} */ (document.getElementById("shareSandboxMode"));
+const shareStatus = /** @type {HTMLDivElement} */ (document.getElementById("shareStatus"));
+const shareResult = /** @type {HTMLDivElement} */ (document.getElementById("shareResult"));
+const shareUrlInput = /** @type {HTMLInputElement} */ (document.getElementById("shareUrl"));
+const shareOwnerKeyInput = /** @type {HTMLInputElement} */ (document.getElementById("shareOwnerKey"));
+const copyShareUrlButton = /** @type {HTMLButtonElement} */ (document.getElementById("copyShareUrl"));
+const copyOwnerKeyButton = /** @type {HTMLButtonElement} */ (document.getElementById("copyOwnerKey"));
 
 const queued = [];
 let annotation = true;
@@ -156,6 +173,74 @@ async function copyFilePath() {
   }, 1200);
 }
 
+function openShareDialog() {
+  shareDialog.hidden = false;
+  shareStatus.textContent = "";
+  shareStatus.classList.remove("error");
+  shareTitleInput.focus();
+}
+
+function closeShareDialog() {
+  shareDialog.hidden = true;
+}
+
+async function copyText(value, button, label) {
+  try {
+    await navigator.clipboard.writeText(value);
+  } catch {
+    const input = document.createElement("textarea");
+    input.value = value;
+    document.body.appendChild(input);
+    input.select();
+    document.execCommand("copy");
+    input.remove();
+  }
+  button.textContent = "Copied";
+  setTimeout(() => {
+    button.textContent = label;
+  }, 1200);
+}
+
+async function publishShare(event) {
+  event.preventDefault();
+  sharePublishButton.disabled = true;
+  shareStatus.classList.remove("error");
+  shareStatus.textContent = "Publishing with HtmlShip...";
+  shareResult.hidden = true;
+
+  try {
+    const response = await fetch("/api/" + key + "/share", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: shareTitleInput.value.trim(),
+        password: sharePasswordInput.value,
+        expires_in: shareExpiresInInput.value,
+        parent_slug: shareParentSlugInput.value.trim(),
+        sandbox_mode: shareSandboxModeInput.value,
+      }),
+    });
+    const data = await response.json();
+    if (!response.ok) {
+      throw new Error(data.error || "HtmlShip publish failed");
+    }
+
+    shareUrlInput.value = data.url || "";
+    shareOwnerKeyInput.value = data.owner_key || "";
+    shareStatus.textContent = data.expires_at
+      ? "Published. This page expires at " + data.expires_at + "."
+      : "Published. Keep the owner key private.";
+    shareResult.hidden = false;
+    shareUrlInput.focus();
+    shareUrlInput.select();
+  } catch (error) {
+    shareStatus.classList.add("error");
+    shareStatus.textContent = error instanceof Error ? error.message : String(error);
+  } finally {
+    sharePublishButton.disabled = false;
+  }
+}
+
 async function reloadAfterServerRestart() {
   let sawOutage = false;
   const deadline = Date.now() + 5000;
@@ -202,6 +287,18 @@ annotationButton.onclick = () => {
 
 sendButton.onclick = sendQueued;
 copyPathButton.onclick = copyFilePath;
+shareButton.onclick = openShareDialog;
+shareCloseButton.onclick = closeShareDialog;
+shareCancelButton.onclick = closeShareDialog;
+shareForm.addEventListener("submit", publishShare);
+shareDialog.addEventListener("click", (event) => {
+  if (event.target === shareDialog) closeShareDialog();
+});
+document.addEventListener("keydown", (event) => {
+  if (event.key === "Escape" && !shareDialog.hidden) closeShareDialog();
+});
+copyShareUrlButton.onclick = () => copyText(shareUrlInput.value, copyShareUrlButton, "Copy URL");
+copyOwnerKeyButton.onclick = () => copyText(shareOwnerKeyInput.value, copyOwnerKeyButton, "Copy Key");
 endButton.onclick = endSession;
 frame.addEventListener("load", () => postToFrame({ type: "lavish:setAnnotationMode", enabled: annotation }));
 

--- a/src/chrome.css
+++ b/src/chrome.css
@@ -107,6 +107,9 @@
 * {
   box-sizing: border-box;
 }
+[hidden] {
+  display: none !important;
+}
 html,
 body {
   margin: 0;
@@ -263,6 +266,142 @@ body.lavish {
 }
 .button.danger:hover:not(:disabled) {
   background: rgba(240, 100, 100, 0.1);
+}
+.share-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  display: grid;
+  place-items: center;
+  padding: var(--space-16);
+  background: rgba(15, 17, 21, 0.72);
+}
+.share-card {
+  width: min(560px, 100%);
+  max-height: min(760px, calc(100vh - 32px));
+  overflow: auto;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-xl);
+  background: var(--bg-panel);
+  color: var(--fg);
+  box-shadow: var(--shadow-floating);
+  padding: var(--space-12);
+}
+.share-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-8);
+  margin-bottom: var(--space-8);
+}
+.share-kicker {
+  color: var(--fg-label);
+  font-size: var(--text-xs);
+  font-weight: var(--w-bold);
+  letter-spacing: var(--track-label);
+  text-transform: uppercase;
+}
+.share-head h2 {
+  margin: var(--space-2) 0 0;
+  font-family: var(--font-serif);
+  font-size: var(--text-2xl);
+  font-style: italic;
+  font-weight: var(--w-regular);
+  line-height: var(--lh-2xl);
+}
+.share-close {
+  width: 30px;
+  height: 30px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--fg-muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: 20px;
+  line-height: 1;
+}
+.share-close:hover {
+  color: var(--fg);
+  border-color: var(--border-strong);
+}
+.share-copy,
+.share-note {
+  margin: 0 0 var(--space-8);
+  color: var(--fg-muted);
+}
+.share-note {
+  color: var(--fg-faint);
+  font-size: var(--text-sm);
+}
+.share-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-8);
+  margin-top: var(--space-10);
+}
+.share-grid label,
+.share-result label {
+  display: grid;
+  gap: var(--space-4);
+  min-width: 0;
+  color: var(--fg-muted);
+  font-size: var(--text-xs);
+  font-weight: var(--w-bold);
+  letter-spacing: var(--track-label);
+  text-transform: uppercase;
+}
+.share-grid input,
+.share-grid select,
+.share-result input {
+  min-width: 0;
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--bg);
+  color: var(--fg);
+  font: inherit;
+  font-size: var(--text-base);
+  font-weight: var(--w-regular);
+  letter-spacing: 0;
+  padding: 10px;
+  text-transform: none;
+}
+.share-grid input::placeholder {
+  color: var(--fg-label);
+}
+.share-status {
+  min-height: 20px;
+  margin-top: var(--space-8);
+  color: var(--fg-muted);
+  font-size: var(--text-sm);
+}
+.share-status.error {
+  color: var(--danger);
+}
+.share-result {
+  display: grid;
+  gap: var(--space-8);
+  margin-top: var(--space-8);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--bg-elevated);
+  padding: var(--space-8);
+}
+.share-copy-row {
+  display: flex;
+  gap: var(--space-6);
+  min-width: 0;
+}
+.share-copy-row input {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+}
+.share-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-8);
+  margin-top: var(--space-12);
 }
 .layout {
   height: calc(100vh - var(--bar-h));
@@ -519,6 +658,16 @@ iframe {
     order: 3;
     flex-basis: 100%;
     font-size: 11px;
+  }
+  .share-overlay {
+    align-items: start;
+    padding: var(--space-8);
+  }
+  .share-grid {
+    grid-template-columns: 1fr;
+  }
+  .share-copy-row {
+    flex-direction: column;
   }
   .layout {
     height: calc(100vh - var(--bar-h));

--- a/src/html-transform.js
+++ b/src/html-transform.js
@@ -1,13 +1,20 @@
+const localDesignAssets =
+  '<link rel="stylesheet" href="/design/daisyui.css" data-lavish-design><script src="/design/tailwindcss-browser.js" data-lavish-design></script><link rel="stylesheet" href="/design/daisyui-themes.css" data-lavish-design>';
+const publicDesignAssets =
+  '<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/daisyui@5.5.19/daisyui.css" data-lavish-design><script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4.2.4/dist/index.global.js" data-lavish-design></script><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/daisyui@5.5.19/themes.css" data-lavish-design>';
+
 export function injectLavishSdk(html, key) {
   const script = `<script src="/sdk.js?key=${encodeURIComponent(key)}"></script>`;
-  const design = shouldInjectDesign(html)
-    ? '<link rel="stylesheet" href="/design/daisyui.css" data-lavish-design><script src="/design/tailwindcss-browser.js" data-lavish-design></script><link rel="stylesheet" href="/design/daisyui-themes.css" data-lavish-design>'
-    : "";
+  const design = shouldInjectDesign(html) ? localDesignAssets : "";
   const withDesign = injectDesignAssets(html, design);
   if (/<\/body\s*>/i.test(withDesign)) {
     return withDesign.replace(/<\/body\s*>/i, `${script}</body>`);
   }
   return `${withDesign}\n${script}`;
+}
+
+export function injectPublicDesignAssets(html) {
+  return injectDesignAssets(html, shouldInjectDesign(html) ? publicDesignAssets : "");
 }
 
 function shouldInjectDesign(html) {

--- a/src/server.js
+++ b/src/server.js
@@ -401,8 +401,13 @@ export async function publishHtmlShipPage(html, options = {}) {
     throw new Error(`HtmlShip publish failed: ${detail}`);
   }
 
+  const url = optionalString(data.url);
+  if (!url) {
+    throw new Error("HtmlShip publish failed: missing url");
+  }
+
   return {
-    url: String(data.url || ""),
+    url,
     slug: String(data.slug || ""),
     owner_key: String(data.owner_key || ""),
     expires_at: data.expires_at || null,

--- a/src/server.js
+++ b/src/server.js
@@ -6,11 +6,13 @@ import chokidar from "chokidar";
 import express from "express";
 
 import { createArtifactSdk } from "./artifact-sdk.js";
-import { injectLavishSdk } from "./html-transform.js";
+import { injectLavishSdk, injectPublicDesignAssets } from "./html-transform.js";
 import { canonicalFile, SessionStore, sessionKey } from "./session-store.js";
 
 const chromeClientUrl = new URL("./chrome-client.js", import.meta.url);
 const chromeCssUrl = new URL("./chrome.css", import.meta.url);
+const htmlShipDefaultApiUrl = "https://api.htmlship.com";
+const htmlShipTimeoutMs = 30000;
 const designAssetUrls = {
   "daisyui.css": {
     packaged: new URL("./design/daisyui.css", import.meta.url),
@@ -144,6 +146,21 @@ export async function serve({ port, stateFile, version = "" }) {
       }
       events.emit("agent-reply", req.params.key, text);
       res.json({ status: "sent" });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.post("/api/:key/share", async (req, res, next) => {
+    try {
+      const session = await store.findByKey(req.params.key);
+      if (!session) {
+        res.status(404).json({ error: "session not found" });
+        return;
+      }
+      const html = await createHtmlShipShareHtml(session.file);
+      const page = await publishHtmlShipPage(html, req.body || {});
+      res.json(page);
     } catch (error) {
       next(error);
     }
@@ -342,6 +359,98 @@ async function readDesignAsset(asset) {
   }
 }
 
+async function createHtmlShipShareHtml(file) {
+  return injectPublicDesignAssets(await readFile(file, "utf8"));
+}
+
+export async function publishHtmlShipPage(html, options = {}) {
+  const apiUrl = String(process.env.HTMLSHIP_API_URL || htmlShipDefaultApiUrl).replace(/\/+$/, "");
+  const headers = {
+    "content-type": "application/json",
+    "user-agent": "lavish-axi/htmlship-share",
+  };
+  if (process.env.HTMLSHIP_API_KEY) {
+    headers.authorization = `Bearer ${process.env.HTMLSHIP_API_KEY}`;
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), htmlShipTimeoutMs);
+  let response;
+  try {
+    response = await fetch(`${apiUrl}/api/v1/pages`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(createHtmlShipPayload(html, options)),
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new Error("HtmlShip publish timed out", { cause: error });
+    }
+    throw new Error(`HtmlShip publish failed: ${error instanceof Error ? error.message : String(error)}`, {
+      cause: error,
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  const text = await response.text();
+  const data = text ? parseJsonResponse(text) : {};
+  if (!response.ok) {
+    const detail = data.detail || data.error || text || `HTTP ${response.status}`;
+    throw new Error(`HtmlShip publish failed: ${detail}`);
+  }
+
+  return {
+    url: String(data.url || ""),
+    slug: String(data.slug || ""),
+    owner_key: String(data.owner_key || ""),
+    expires_at: data.expires_at || null,
+    created_at: data.created_at || null,
+  };
+}
+
+export function createHtmlShipPayload(html, options = {}) {
+  const body = {
+    html: String(html || ""),
+    sandbox_mode: optionalString(options.sandbox_mode || options.sandboxMode) || "strict",
+  };
+  const title = optionalString(options.title);
+  const password = optionalString(options.password);
+  const parentSlug = optionalString(options.parent_slug || options.parentSlug);
+  const expiresIn = normalizeExpiresIn(options.expires_in ?? options.expiresIn);
+
+  if (title) body.title = title;
+  if (password) body.password = password;
+  if (parentSlug) body.parent_slug = parentSlug;
+  if (expiresIn !== null) body.expires_in = expiresIn;
+
+  return body;
+}
+
+function optionalString(value) {
+  return String(value ?? "").trim();
+}
+
+function normalizeExpiresIn(value) {
+  if (value === undefined || value === null || value === "") {
+    return null;
+  }
+  const number = Number(value);
+  if (!Number.isInteger(number) || number < 1 || number > 10080) {
+    throw new Error("expires_in must be an integer from 1 to 10080 minutes");
+  }
+  return number;
+}
+
+function parseJsonResponse(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { detail: text };
+  }
+}
+
 export function resolveArtifactAsset(root, assetPath) {
   const file = path.resolve(root, assetPath);
   const relative = path.relative(root, file);
@@ -384,6 +493,7 @@ function setPollActive(key, activePolls, events, active) {
 
 export function createChromeHtml(session) {
   const fileInputSize = Math.max(1, session.file.length);
+  const defaultShareTitle = path.basename(session.file);
   const sessionJson = jsonScript({ key: session.key, initialChat: session.chat || [] });
   return `<!doctype html>
 <html>
@@ -394,7 +504,8 @@ export function createChromeHtml(session) {
 <link rel="stylesheet" href="/chrome.css">
 </head>
 <body class="lavish">
-<div class="bar"><div class="brand"><span class="brand-mark">Lavish</span><span class="brand-support">Editor</span></div><div class="divider" aria-hidden="true"></div><div class="file-wrap" title="${escapeHtml(session.file)}"><input class="file-input" id="filePath" readonly size="${fileInputSize}" value="${escapeHtml(session.file)}"><button class="copy-button" id="copyPath" type="button">Copy Path</button></div><button class="button secondary annotation-on" id="annotation">Annotation: On</button><button class="button danger" id="end">End Session</button></div>
+<div class="bar"><div class="brand"><span class="brand-mark">Lavish</span><span class="brand-support">Editor</span></div><div class="divider" aria-hidden="true"></div><div class="file-wrap" title="${escapeHtml(session.file)}"><input class="file-input" id="filePath" readonly size="${fileInputSize}" value="${escapeHtml(session.file)}"><button class="copy-button" id="copyPath" type="button">Copy Path</button></div><button class="button secondary" id="share" type="button">Share</button><button class="button secondary annotation-on" id="annotation">Annotation: On</button><button class="button danger" id="end">End Session</button></div>
+<div class="share-overlay" id="shareDialog" role="dialog" aria-modal="true" aria-labelledby="shareTitleText" hidden><form class="share-card" id="shareForm"><div class="share-head"><div><div class="share-kicker">Powered by htmlship.com</div><h2 id="shareTitleText">Publish a share URL</h2></div><button class="share-close" id="shareClose" type="button" aria-label="Close share dialog">×</button></div><p class="share-copy">This sends the current HTML file to HtmlShip and serves a copy from view.htmlship.com. Password-protect anything that should not be public.</p><p class="share-note">Lavish design assets are rewritten to public CDN links. The annotation SDK is not included. Local sibling assets may not resolve on the shared page.</p><div class="share-grid"><label>Title<input id="shareTitle" name="title" type="text" value="${escapeHtml(defaultShareTitle)}" autocomplete="off"></label><label>Password<input id="sharePassword" name="password" type="password" autocomplete="new-password" placeholder="Optional view password"></label><label>Expires in minutes<input id="shareExpiresIn" name="expires_in" type="number" min="1" max="10080" step="1" placeholder="Optional, max 10080"></label><label>Parent slug<input id="shareParentSlug" name="parent_slug" type="text" autocomplete="off" placeholder="Optional version parent"></label><label>Sandbox mode<select id="shareSandboxMode" name="sandbox_mode"><option value="strict">Strict</option><option value="relaxed" selected>Relaxed</option></select></label></div><div class="share-status" id="shareStatus" role="status"></div><div class="share-result" id="shareResult" hidden><label>Share URL<div class="share-copy-row"><input id="shareUrl" readonly><button class="copy-button" id="copyShareUrl" type="button">Copy URL</button></div></label><label>Owner key<div class="share-copy-row"><input id="shareOwnerKey" readonly><button class="copy-button" id="copyOwnerKey" type="button">Copy Key</button></div></label><p class="share-note">Keep the owner key private. HtmlShip returns it once, and it can update or delete this page.</p></div><div class="share-actions"><button class="button secondary" id="shareCancel" type="button">Cancel</button><button class="button" id="sharePublish" type="submit">Publish Page</button></div></form></div>
 <div class="layout"><div class="frame"><iframe id="artifact" sandbox="allow-scripts allow-forms allow-popups allow-downloads" src="/artifact/${session.key}/index.html"></iframe></div><aside class="panel"><h2>Conversation</h2><div class="chat" id="chatLog"></div><div class="composer"><div class="annotation-pills" id="annotationPills"></div><textarea id="chatInput" placeholder="Write a message for the agent..."></textarea><div class="actions"><button class="button" id="send">Send to Agent</button></div></div></aside></div>
 <script id="lavish-session" type="application/json">${sessionJson}</script>
 <script src="/chrome-client.js"></script>

--- a/src/server.js
+++ b/src/server.js
@@ -153,6 +153,10 @@ export async function serve({ port, stateFile, version = "" }) {
 
   app.post("/api/:key/share", async (req, res, next) => {
     try {
+      if (!isSameOriginRequest(req)) {
+        res.status(403).json({ error: "cross-origin share request rejected" });
+        return;
+      }
       const session = await store.findByKey(req.params.key);
       if (!session) {
         res.status(404).json({ error: "session not found" });
@@ -453,6 +457,24 @@ function parseJsonResponse(text) {
     return JSON.parse(text);
   } catch {
     return { detail: text };
+  }
+}
+
+function isSameOriginRequest(req) {
+  const expectedOrigin = `${req.protocol}://${req.get("host")}`;
+  const origin = req.get("origin");
+  if (origin) {
+    return normalizeOrigin(origin) === expectedOrigin;
+  }
+  const referer = req.get("referer");
+  return !referer || normalizeOrigin(referer) === expectedOrigin;
+}
+
+function normalizeOrigin(value) {
+  try {
+    return new URL(value).origin;
+  } catch {
+    return "";
   }
 }
 

--- a/test/html-transform.test.js
+++ b/test/html-transform.test.js
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { injectLavishSdk } from "../src/html-transform.js";
+import { injectLavishSdk, injectPublicDesignAssets } from "../src/html-transform.js";
 
 test("injects the Lavish SDK before the closing body tag", () => {
   const html = "<!doctype html><html><body><h1>Hi</h1></body></html>";
@@ -50,4 +50,23 @@ test("appends the Lavish SDK when the artifact has no body tag", () => {
 
   assert.match(result, /<h1>Hi<\/h1>\n<link rel="stylesheet" href="\/design\/daisyui\.css" data-lavish-design>/);
   assert.match(result, /<script src="\/sdk\.js\?key=abc123"><\/script>$/);
+});
+
+test("injects public design assets for shared HtmlShip pages without the Lavish SDK", () => {
+  const html = '<!doctype html><html><head><title>Hi</title></head><body><h1 class="btn">Hi</h1></body></html>';
+  const result = injectPublicDesignAssets(html);
+
+  assert.match(result, /https:\/\/cdn\.jsdelivr\.net\/npm\/daisyui@5\.5\.19\/daisyui\.css/);
+  assert.match(result, /https:\/\/cdn\.jsdelivr\.net\/npm\/@tailwindcss\/browser@4\.2\.4\/dist\/index\.global\.js/);
+  assert.match(result, /https:\/\/cdn\.jsdelivr\.net\/npm\/daisyui@5\.5\.19\/themes\.css/);
+  assert.match(result, /data-lavish-design>[\s\S]*<title>Hi<\/title>/);
+  assert.doesNotMatch(result, /\/design\//);
+  assert.doesNotMatch(result, /\/sdk\.js/);
+});
+
+test("public share design injection respects Lavish design opt out", () => {
+  const html = '<!doctype html><html><head><meta name="lavish-design" content="off"></head><body></body></html>';
+  const result = injectPublicDesignAssets(html);
+
+  assert.equal(result, html);
 });

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -271,6 +272,44 @@ test("chrome can copy the file path from the top bar", async () => {
   assert.match(js, /copyPathButton\.textContent = "Copy Path"/);
 });
 
+test("chrome exposes an HtmlShip share modal from the top bar", async () => {
+  const html = createChromeHtml({ key: "abc", file: "/tmp/artifact.html" });
+  const css = await chromeCssSource();
+
+  assert.match(html, /id="share"/);
+  assert.match(html, />Share</);
+  assert.match(html, /id="shareDialog"/);
+  assert.match(html, /Powered by htmlship\.com/);
+  assert.match(html, /id="shareTitle"/);
+  assert.match(html, /id="sharePassword"/);
+  assert.match(html, /id="shareExpiresIn"/);
+  assert.match(html, /id="shareParentSlug"/);
+  assert.match(html, /id="shareSandboxMode"/);
+  assert.match(html, /<option value="strict">Strict<\/option>/);
+  assert.match(html, /<option value="relaxed" selected>Relaxed<\/option>/);
+  assert.match(html, /Publish Page/);
+  assert.match(html, /Lavish design assets are rewritten to public CDN links/);
+  assert.match(html, /The annotation SDK is not included/);
+  assert.match(css, /\.share-overlay/);
+  assert.match(css, /box-shadow:var\(--shadow-floating\)/);
+  assert.match(css, /\.share-card/);
+});
+
+test("chrome client posts share settings and renders the HtmlShip URL", async () => {
+  const js = await chromeClientSource();
+
+  assert.match(js, /const shareButton/);
+  assert.match(js, /async function publishShare/);
+  assert.match(js, /fetch\("\/api\/" \+ key \+ "\/share"/);
+  assert.match(js, /title: shareTitleInput\.value\.trim\(\)/);
+  assert.match(js, /password: sharePasswordInput\.value/);
+  assert.match(js, /expires_in: shareExpiresInInput\.value/);
+  assert.match(js, /parent_slug: shareParentSlugInput\.value\.trim\(\)/);
+  assert.match(js, /sandbox_mode: shareSandboxModeInput\.value/);
+  assert.match(js, /shareUrlInput\.value = data\.url/);
+  assert.match(js, /shareOwnerKeyInput\.value = data\.owner_key/);
+});
+
 test("chrome centers the top bar row while bottom-aligning the identity cluster", async () => {
   const css = await chromeCssSource();
 
@@ -504,6 +543,76 @@ test("/design serves local Tailwind and DaisyUI artifact assets", async () => {
   }
 });
 
+test("POST /api/:key/share publishes the artifact HTML through HtmlShip", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "lavish-serve-"));
+  const artifact = path.join(dir, "artifact.html");
+  await writeFile(artifact, "<!doctype html><title>Artifact</title><h1>Ship me</h1>\n");
+
+  const requests = [];
+  const htmlShipApi = await startFakeHtmlShipApi(requests);
+  const previousApiUrl = process.env.HTMLSHIP_API_URL;
+  const previousApiKey = process.env.HTMLSHIP_API_KEY;
+  process.env.HTMLSHIP_API_URL = `http://127.0.0.1:${serverPort(htmlShipApi)}`;
+  process.env.HTMLSHIP_API_KEY = "test-token";
+
+  const server = await serve({ port: 0, stateFile: path.join(dir, "state.json"), version: "9.9.9-test" });
+  try {
+    const base = `http://127.0.0.1:${server.port}`;
+    const sessionRes = await fetch(`${base}/api/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ file: artifact }),
+    });
+    const session = await sessionRes.json();
+
+    const shareRes = await fetch(`${base}/api/${session.key}/share`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Review draft",
+        password: "demo-pass",
+        expires_in: "60",
+        parent_slug: "parent123",
+        sandbox_mode: "strict",
+      }),
+    });
+    const body = await shareRes.json();
+
+    assert.equal(shareRes.status, 200);
+    assert.deepEqual(body, {
+      url: "https://view.htmlship.com/share123",
+      slug: "share123",
+      owner_key: "ws_secret",
+      expires_at: "2026-05-12T13:00:00.000Z",
+      created_at: "2026-05-12T12:00:00.000Z",
+    });
+    assert.equal(requests.length, 1);
+    assert.equal(requests[0].method, "POST");
+    assert.equal(requests[0].url, "/api/v1/pages");
+    assert.equal(requests[0].headers.authorization, "Bearer test-token");
+    assert.match(requests[0].body.html, /^<!doctype html><title>Artifact<\/title><h1>Ship me<\/h1>\n/);
+    assert.match(requests[0].body.html, /https:\/\/cdn\.jsdelivr\.net\/npm\/daisyui@5\.5\.19\/daisyui\.css/);
+    assert.match(
+      requests[0].body.html,
+      /https:\/\/cdn\.jsdelivr\.net\/npm\/@tailwindcss\/browser@4\.2\.4\/dist\/index\.global\.js/,
+    );
+    assert.match(requests[0].body.html, /https:\/\/cdn\.jsdelivr\.net\/npm\/daisyui@5\.5\.19\/themes\.css/);
+    assert.doesNotMatch(requests[0].body.html, /\/sdk\.js/);
+    assert.doesNotMatch(requests[0].body.html, /\/design\//);
+    assert.equal(requests[0].body.title, "Review draft");
+    assert.equal(requests[0].body.password, "demo-pass");
+    assert.equal(requests[0].body.expires_in, 60);
+    assert.equal(requests[0].body.parent_slug, "parent123");
+    assert.equal(requests[0].body.sandbox_mode, "strict");
+  } finally {
+    await server.close();
+    await closeServer(htmlShipApi);
+    restoreEnv("HTMLSHIP_API_URL", previousApiUrl);
+    restoreEnv("HTMLSHIP_API_KEY", previousApiKey);
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("POST /shutdown stops the listener so the client can spawn a fresh server", async () => {
   const dir = await mkdtemp(path.join(tmpdir(), "lavish-serve-"));
   const server = await serve({ port: 0, stateFile: path.join(dir, "state.json"), version: "9.9.9-test" });
@@ -530,3 +639,55 @@ test("ended session message renders centered in the main content area", async ()
   assert.doesNotMatch(js, /The agent polling loop can stop\./);
   assert.doesNotMatch(js, /<span class="file">Session ended\. The agent polling loop can stop\.<\/span>/);
 });
+
+async function startFakeHtmlShipApi(requests) {
+  const server = createServer((req, res) => {
+    let raw = "";
+    req.setEncoding("utf8");
+    req.on("data", (chunk) => {
+      raw += chunk;
+    });
+    req.on("end", () => {
+      requests.push({
+        method: req.method,
+        url: req.url,
+        headers: req.headers,
+        body: raw ? JSON.parse(raw) : null,
+      });
+      res.writeHead(201, { "content-type": "application/json" });
+      res.end(
+        JSON.stringify({
+          url: "https://view.htmlship.com/share123",
+          slug: "share123",
+          owner_key: "ws_secret",
+          expires_at: "2026-05-12T13:00:00.000Z",
+          created_at: "2026-05-12T12:00:00.000Z",
+        }),
+      );
+    });
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+  return server;
+}
+
+function serverPort(server) {
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("expected TCP server address");
+  }
+  return address.port;
+}
+
+async function closeServer(server) {
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function restoreEnv(name, value) {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { createChromeHtml, createSdkJs, resolveArtifactAsset, serve } from "../src/server.js";
+import { createChromeHtml, createSdkJs, publishHtmlShipPage, resolveArtifactAsset, serve } from "../src/server.js";
 
 async function chromeClientSource() {
   return readFile(new URL("../src/chrome-client.js", import.meta.url), "utf8");
@@ -613,6 +613,24 @@ test("POST /api/:key/share publishes the artifact HTML through HtmlShip", async 
   }
 });
 
+test("publishHtmlShipPage rejects successful HtmlShip responses without a URL", async () => {
+  const requests = [];
+  const htmlShipApi = await startFakeHtmlShipApi(requests, { slug: "share123", owner_key: "ws_secret" });
+  const previousApiUrl = process.env.HTMLSHIP_API_URL;
+  process.env.HTMLSHIP_API_URL = `http://127.0.0.1:${serverPort(htmlShipApi)}`;
+
+  try {
+    await assert.rejects(
+      () => publishHtmlShipPage("<!doctype html><title>Artifact</title>"),
+      /HtmlShip publish failed: missing url/,
+    );
+    assert.equal(requests.length, 1);
+  } finally {
+    await closeServer(htmlShipApi);
+    restoreEnv("HTMLSHIP_API_URL", previousApiUrl);
+  }
+});
+
 test("POST /shutdown stops the listener so the client can spawn a fresh server", async () => {
   const dir = await mkdtemp(path.join(tmpdir(), "lavish-serve-"));
   const server = await serve({ port: 0, stateFile: path.join(dir, "state.json"), version: "9.9.9-test" });
@@ -640,7 +658,14 @@ test("ended session message renders centered in the main content area", async ()
   assert.doesNotMatch(js, /<span class="file">Session ended\. The agent polling loop can stop\.<\/span>/);
 });
 
-async function startFakeHtmlShipApi(requests) {
+async function startFakeHtmlShipApi(requests, responseBody = null) {
+  const htmlShipResponse = responseBody ?? {
+    url: "https://view.htmlship.com/share123",
+    slug: "share123",
+    owner_key: "ws_secret",
+    expires_at: "2026-05-12T13:00:00.000Z",
+    created_at: "2026-05-12T12:00:00.000Z",
+  };
   const server = createServer((req, res) => {
     let raw = "";
     req.setEncoding("utf8");
@@ -655,15 +680,7 @@ async function startFakeHtmlShipApi(requests) {
         body: raw ? JSON.parse(raw) : null,
       });
       res.writeHead(201, { "content-type": "application/json" });
-      res.end(
-        JSON.stringify({
-          url: "https://view.htmlship.com/share123",
-          slug: "share123",
-          owner_key: "ws_secret",
-          expires_at: "2026-05-12T13:00:00.000Z",
-          created_at: "2026-05-12T12:00:00.000Z",
-        }),
-      );
+      res.end(JSON.stringify(htmlShipResponse));
     });
   });
   await new Promise((resolve) => server.listen(0, "127.0.0.1", () => resolve()));

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -613,6 +613,44 @@ test("POST /api/:key/share publishes the artifact HTML through HtmlShip", async 
   }
 });
 
+test("POST /api/:key/share rejects cross-origin browser requests", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "lavish-serve-"));
+  const artifact = path.join(dir, "artifact.html");
+  await writeFile(artifact, "<!doctype html><title>Artifact</title><h1>Private</h1>\n");
+
+  const requests = [];
+  const htmlShipApi = await startFakeHtmlShipApi(requests);
+  const previousApiUrl = process.env.HTMLSHIP_API_URL;
+  process.env.HTMLSHIP_API_URL = `http://127.0.0.1:${serverPort(htmlShipApi)}`;
+
+  const server = await serve({ port: 0, stateFile: path.join(dir, "state.json"), version: "9.9.9-test" });
+  try {
+    const base = `http://127.0.0.1:${server.port}`;
+    const sessionRes = await fetch(`${base}/api/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ file: artifact }),
+    });
+    const session = await sessionRes.json();
+
+    const shareRes = await fetch(`${base}/api/${session.key}/share`, {
+      method: "POST",
+      headers: { "content-type": "application/json", origin: "https://attacker.example" },
+      body: JSON.stringify({ title: "stolen" }),
+    });
+    const body = await shareRes.json();
+
+    assert.equal(shareRes.status, 403);
+    assert.deepEqual(body, { error: "cross-origin share request rejected" });
+    assert.equal(requests.length, 0);
+  } finally {
+    await server.close();
+    await closeServer(htmlShipApi);
+    restoreEnv("HTMLSHIP_API_URL", previousApiUrl);
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("publishHtmlShipPage rejects successful HtmlShip responses without a URL", async () => {
   const requests = [];
   const htmlShipApi = await startFakeHtmlShipApi(requests, { slug: "share123", owner_key: "ws_secret" });


### PR DESCRIPTION
## Intent

The developer wanted to recover UI/design-system changes they believed were lost after conflict resolution, first checking a feature branch and then diagnosing why the browser still showed an old Lavish Editor chrome UI. They needed the stale local server issue resolved, then asked for a tested fix to the published package bug where the CLI could not spawn the server from dist. They also wanted a robust client/server version mismatch solution so upgrading lavish-axi fully replaces old running servers, including graceful shutdown, fallback handling for older servers, and automatic browser refresh. Finally, they wanted the technical-plan marketing demo preserved or recovered while dropping the research-report demo.

## What Changed

- Adds a Share flow to the Lavish Editor chrome that publishes the current artifact through HtmlShip with title, password, expiration, parent slug, and sandbox options.
- Adds the server-side share endpoint and HtmlShip publishing integration, including same-origin protection and validation of required share URL responses.
- Updates HTML transform behavior and documentation for shared artifacts, including public CDN design assets, omitted annotation SDK, and local asset limitations.

## Risk Assessment

✅ Low: The changes are narrowly scoped to an explicit share flow with server-side validation, error handling for missing HtmlShip URLs, and a same-origin gate on the publishing endpoint.

## Testing

- Summary: Exercised the HtmlShip share HTML transformation, server publish endpoint, chrome share UI assertions, and the full existing Node test suite; everything passed.
- `node --test test/html-transform.test.js`
- `node --test test/server.test.js`
- `npm test`
- Outcome: ✅ passed across 1 run (59.3s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2)</summary>

**Round 1** - found 1 warning
- ⚠️ `src/server.js:405` - `publishHtmlShipPage` treats a 2xx HtmlShip response with a missing `url` as success and returns an empty share URL, so the chrome UI can tell the user the page was published while giving them nothing usable to open or copy. Validate required response fields such as `url` and surface an error when they are absent.

**Round 2** (auto-fix) - found 1 error
- 🚨 `src/server.js:154` - `POST /api/:key/share` accepts any browser-originated POST that knows or obtains the session key, and this new endpoint uploads the local artifact HTML to an external public sharing service. Because session keys appear in localhost URLs and can leak through artifact-loaded remote resources or browser history/referrers, require a same-origin check or an unguessable per-session CSRF token before publishing.

**Round 3** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `node --test test/html-transform.test.js`
- `node --test test/server.test.js`
- `npm test`

</details>

<details>
<summary>🔧 **Document** - 4 issues found → auto-fixed (2)</summary>

**Round 1** - found 4 warnings
- ⚠️ `README.md:36` - The README still promises &#34;Local only&#34; and &#34;Zero cloud dependency,&#34; but the change adds a Share button that posts the current HTML to HtmlShip and serves it from view.htmlship.com. Update the user-facing README to describe the optional HtmlShip sharing flow, privacy implications, password/expiration controls, and the fact that local review remains local unless the user publishes.
- ⚠️ `README.md:98` - The README explains local artifact injection but does not document the new shared-page behavior: Lavish design assets are rewritten to public CDN URLs, the annotation SDK is omitted, and local sibling assets may not resolve on HtmlShip. Add these limitations near the feature or How It Works documentation so users know what will differ after publishing.
- ⚠️ `AGENTS.md:42` - The architecture request flow omits the new `POST /api/:key/share` path and `publishHtmlShipPage` integration. Update this maintainer documentation to cover the Share dialog, same-origin check, payload fields, HtmlShip `/api/v1/pages` call, and returned URL/owner key.
- ⚠️ `AGENTS.md:64` - The code introduces HtmlShip configuration through `HTMLSHIP_API_URL` and optional `HTMLSHIP_API_KEY`, but the repo documentation only lists existing Lavish and telemetry environment variables. Add a short HtmlShip/sharing configuration note so maintainers and testers know how to point sharing at a custom API and how bearer auth is enabled.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `.agents/skills/lavish-design/ui_kits/editor/README.md:20` - The UI kit README still describes the top bar as only brand, file path, annotation toggle, and End Session, and its walkthrough skips directly from queued prompts to the annotation toggle/end flow. The change adds a Share button and HtmlShip share dialog to the canonical Lavish Editor chrome, so this README should document the Share control and note whether the kit intentionally omits or recreates the HtmlShip sharing flow.

**Round 3** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
