### PR TITLE
docs(cli): clarify Lavish agent guidance

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -16,7 +16,8 @@ import { initDefaultTelemetry } from "./telemetry.js";
 
 const COMMANDS = new Set(["open", "poll", "end", "server", "playbook", "design"]);
 const DESCRIPTION =
-  "Lavish Editor helps agents turn rich HTML artifacts into collaborative human review surfaces. First generate an interactive HTML artifact according to user request, then run `lavish-axi <html-file>` so the user can visually review it, annotate elements or selected text, queue prompts, and send feedback back through `lavish-axi poll`.";
+  "Lavish Editor helps agents turn rich HTML artifacts into collaborative human review surfaces. Whenever you are about to give user a complex response that will be easier to understand via a rich / interactive page, consider using Lavish Editor. " +
+  "First generate an interactive HTML artifact according to user request, then run `lavish-axi <html-file>` so the user can visually review it, annotate elements or selected text, queue prompts, and send feedback back through `lavish-axi poll`.";
 // Inlined at build time from package.json; falls back to reading package.json so source-run tests work.
 export const VERSION =
   process.env.LAVISH_AXI_BUILD_VERSION ||
@@ -150,7 +151,7 @@ export function createPlaybookOutput(args) {
 export function createOpenOutput({ file, url, status }) {
   return {
     session: { file, url, status },
-    next_step: `Tell the user to open ${url} to review the artifact in Lavish Editor, then run \`lavish-axi poll ${file}\`. This command long-polls until the user sends feedback or ends the session. Do not pass --timeout-ms during normal agent use. Do not set a short shell timeout; either run it without a timeout or set the shell timeout above 10 minutes. After applying feedback, run \`lavish-axi poll ${file} --agent-reply "<message for the user>"\` without --timeout-ms to show your response in Lavish Editor and wait for more feedback.`,
+    next_step: `Run \`lavish-axi poll ${file}\`. This command long-polls until the user sends feedback or ends the session. Do not pass --timeout-ms during normal agent use. Do not set a short shell timeout; either run it without a timeout or set the shell timeout above 10 minutes. After applying feedback, run \`lavish-axi poll ${file} --agent-reply "<message for the user>"\` without --timeout-ms to show your response in Lavish Editor and wait for more feedback.`,
   };
 }
 

--- a/test/cli-output.test.js
+++ b/test/cli-output.test.js
@@ -170,7 +170,7 @@ test("home directory collapse tolerates Windows mixed separators", () => {
   );
 });
 
-test("open output uses one next_step string for user URL and polling", () => {
+test("open output keeps the user URL in session data and next_step focused on polling", () => {
   const output = createOpenOutput({
     file: "/tmp/artifact.html",
     url: "http://localhost:4387/session/abc123",
@@ -181,7 +181,8 @@ test("open output uses one next_step string for user URL and polling", () => {
   assert.equal(output.session.url, "http://localhost:4387/session/abc123");
   assert.equal(output.session.status, "opened");
   assert.equal(typeof output.next_step, "string");
-  assert.match(output.next_step, /Tell the user to open http:\/\/localhost:4387\/session\/abc123/);
+  assert.doesNotMatch(output.next_step, /Tell the user/i);
+  assert.doesNotMatch(output.next_step, /http:\/\/localhost:4387\/session\/abc123/);
   assert.match(output.next_step, /lavish-axi poll \/tmp\/artifact\.html/);
   assert.match(output.next_step, /long-polls until/);
   assert.match(output.next_step, /do not set a short shell timeout/i);

--- a/test/cli-output.test.js
+++ b/test/cli-output.test.js
@@ -37,6 +37,8 @@ test("home output teaches agents when and how to use Lavish Editor", () => {
 
   assert.equal(output.bin, "~/.local/bin/lavish-axi");
   assert.match(output.description, /Lavish Editor/);
+  assert.match(output.description, /complex response/);
+  assert.match(output.description, /consider using Lavish Editor/);
   assert.match(output.description, /First generate an interactive HTML artifact/);
   assert.deepEqual(output.sessions, []);
   assert.equal("use_cases" in output, false);


### PR DESCRIPTION
## Intent

The developer wanted help fixing tests after intentionally changing open command output behavior in Lavish AXI. Their goal was to remove the phrase "Tell the user" and the session URL from the `next_step` polling instruction while keeping `session.url` available separately. They also wanted to understand how to enable `pnpm` via Corepack so it is available on PATH, why verification output showed `npm` despite using `pnpm`, whether hardcoding `pnpm` in `package.json` scripts is generally advisable, and what `run-s` means.

## What Changed

- Expanded the CLI home description to prompt agents to consider Lavish Editor for complex responses that benefit from a rich or interactive page.
- Updated open output so `next_step` focuses on polling instructions while keeping the review URL available separately in `session.url`.
- Adjusted CLI output tests to cover the revised guidance and URL separation behavior.

## Risk Assessment

✅ Low: The branch only changes CLI guidance text and the corresponding output assertion, with the session URL still preserved in structured session data.

## Testing

- Summary: After installing locked dependencies, I exercised the changed CLI guidance output paths and then ran the full Node test suite; everything passed.
- `node --test --test-name-pattern "open output keeps the user URL" test/cli-output.test.js`
- `node --test --test-name-pattern "home output teaches agents" test/cli-output.test.js`
- `node --test test/cli-output.test.js`
- `pnpm test`
- Outcome: ✅ passed across 1 run (1m20s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `node --test --test-name-pattern "open output keeps the user URL" test/cli-output.test.js`
- `node --test --test-name-pattern "home output teaches agents" test/cli-output.test.js`
- `node --test test/cli-output.test.js`
- `pnpm test`

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
