### PR TITLE
fix: unify agent-working event semantics and allow queued input when agent is not polling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ State lives at `~/.lavish-axi/state.json` (override with `LAVISH_AXI_STATE_DIR`)
 4. Sibling assets resolve under `/artifact/:key/<path>`, sandboxed to the artifact's directory (`resolveArtifactAsset` rejects paths that escape via `..`), while packaged Tailwind/DaisyUI assets are served from `/design/:asset`.
 5. User actions in the iframe `postMessage` to the chrome (queue prompts, request snapshot, end session). The chrome POSTs collected prompts to `/api/:key/prompts`, which queues them in the session store and emits a `feedback` event. Text selection prompts use `tag: "text"` and preserve a structured `target` with `type: "text-range"`, selected text, `commonAncestorSelector`, and start/end boundary anchors.
 6. `lavish-axi poll <file.html>` (`pollCommand`) hits `GET /api/poll`. If queued prompts exist, it returns immediately; otherwise it long-polls on an `EventEmitter` until a `feedback` or `ended` event fires (default: no timeout - `--timeout-ms` is a test escape hatch).
-7. `--agent-reply` posts a chat message into the session before polling, so the agent's reply renders in the browser conversation panel via the `/events/:key` SSE stream.
+7. `--agent-reply` posts a chat message into the session before polling, so the agent's reply renders in the browser conversation panel via the `/events/:key` SSE stream, which also carries `agent-working` events (`working: true` when the agent has an active poll).
 
 ### Live reload
 

--- a/src/chrome-client.js
+++ b/src/chrome-client.js
@@ -111,8 +111,6 @@ function postToFrame(message) {
 }
 
 function sendQueued() {
-  if (!agentPolling) return;
-
   const text = chatInput.value.trim();
   if (text) {
     queued.push({ uid: "", prompt: text, selector: "", tag: "message", text: "Freeform message" });
@@ -214,7 +212,7 @@ events.addEventListener("reload", () => {
 events.addEventListener("chrome-reload", () => reloadAfterServerRestart());
 events.addEventListener("agent-reply", (event) => addChat("agent", JSON.parse(event.data).text));
 events.addEventListener("chat-sync", (event) => syncChat(JSON.parse(event.data).chat || []));
-events.addEventListener("agent-working", (event) => setAgentPolling(!JSON.parse(event.data).working));
+events.addEventListener("agent-working", (event) => setAgentPolling(JSON.parse(event.data).working));
 
 render();
 initialChat.forEach((item) => addChat(item.role, item.text));

--- a/src/server.js
+++ b/src/server.js
@@ -240,7 +240,7 @@ export async function serve({ port, stateFile, version = "" }) {
         }
       };
       res.write(`event: chat-sync\ndata: ${JSON.stringify({ chat: session?.chat || [] })}\n\n`);
-      res.write(`event: agent-working\ndata: ${JSON.stringify({ working: !activePolls.has(req.params.key) })}\n\n`);
+      res.write(`event: agent-working\ndata: ${JSON.stringify({ working: activePolls.has(req.params.key) })}\n\n`);
       events.on("reload", sendReload);
       events.on("agent-reply", sendAgentReply);
       events.on("agent-working", sendWorking);
@@ -379,7 +379,7 @@ function setPollActive(key, activePolls, events, active) {
     activePolls.set(key, nextCount);
   }
   if (count > 0 === nextCount > 0) return;
-  events.emit("agent-working", key, nextCount === 0);
+  events.emit("agent-working", key, nextCount > 0);
 }
 
 export function createChromeHtml(session) {

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -342,12 +342,12 @@ test("chrome shows agent working state when no poll is active", async () => {
   assert.match(js, /spinner/);
 });
 
-test("chrome disables sending while agent is working", async () => {
+test("chrome shows working indicator and controls button state based on agent polling", async () => {
   const js = await chromeClientSource();
 
   assert.match(js, /let agentPolling = false/);
   assert.match(js, /sendButton\.disabled = !agentPolling/);
-  assert.match(js, /if \(!agentPolling\) return/);
+  assert.match(js, /Working\.\.\./);
 });
 
 test("chrome puts queued annotations inside the chat composer as preview pills", async () => {

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -44,6 +44,13 @@ test("server serves chrome styles from a dedicated source file", async () => {
   assert.match(source, /chrome\.css/);
   assert.match(html, /<link rel="stylesheet" href="\/chrome\.css">/);
   assert.doesNotMatch(html, /<style>/);
+});
+
+test("server emits agent-working with unified polling semantics", async () => {
+  const source = await readFile(new URL("../src/server.js", import.meta.url), "utf8");
+
+  assert.match(source, /events\.emit\("agent-working", key, nextCount > 0\)/);
+  assert.match(source, /working: activePolls\.has\(req\.params\.key\)/);
 });
 
 test("artifact assets resolve within the artifact directory", () => {
@@ -350,6 +357,12 @@ test("chrome shows working indicator and controls button state based on agent po
   assert.match(js, /Working\.\.\./);
 });
 
+test("chrome allows queuing input while agent is not polling", async () => {
+  const js = await chromeClientSource();
+
+  assert.doesNotMatch(js, /if\s*\(\s*!agentPolling\s*\)\s*return/);
+});
+
 test("chrome puts queued annotations inside the chat composer as preview pills", async () => {
   const html = createChromeHtml({ key: "abc", file: "/tmp/artifact.html" });
   const js = await chromeClientSource();
@@ -513,6 +526,68 @@ test("POST /shutdown stops the listener so the client can spawn a fresh server",
     await server.done;
     await assert.rejects(() => fetch(`http://127.0.0.1:${server.port}/health`), /fetch failed|ECONNREFUSED/);
   } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("SSE initial agent-working is false without poll and true with active poll", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "lavish-serve-"));
+  const server = await serve({ port: 0, stateFile: path.join(dir, "state.json"), version: "9.9.9-test" });
+  try {
+    const artifact = path.join(dir, "artifact.html");
+    await writeFile(artifact, "<html><body>hello</body></html>");
+    const sessionRes = await fetch(`http://127.0.0.1:${server.port}/api/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ file: artifact }),
+    });
+    const { key } = await sessionRes.json();
+
+    async function readWorkingEvent(eventUrl) {
+      const res = await fetch(eventUrl);
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+      const deadline = Date.now() + 1000;
+      while (Date.now() < deadline) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const chunks = buffer.split("\n\n");
+        buffer = chunks.pop();
+        for (const chunk of chunks) {
+          const lines = chunk.split("\n");
+          if (lines.some((l) => l === "event: agent-working")) {
+            const dataLine = lines.find((l) => l.startsWith("data: "));
+            reader.cancel();
+            return JSON.parse(dataLine.slice(6));
+          }
+        }
+      }
+      reader.cancel();
+      return null;
+    }
+
+    const noPoll = await readWorkingEvent(`http://127.0.0.1:${server.port}/events/${key}`);
+    assert.ok(noPoll);
+    assert.equal(noPoll.working, false);
+
+    const controller = new AbortController();
+    const pollPromise = fetch(
+      `http://127.0.0.1:${server.port}/api/poll?file=${encodeURIComponent(artifact)}&timeoutMs=5000`,
+      { signal: controller.signal },
+    );
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    const withPoll = await readWorkingEvent(`http://127.0.0.1:${server.port}/events/${key}`);
+    assert.ok(withPoll);
+    assert.equal(withPoll.working, true);
+
+    controller.abort();
+    await assert.rejects(() => pollPromise, /AbortError/);
+  } finally {
+    await server.close();
     await rm(dir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
Closes #27.

All checks passed through no-mistakes gate.

- Review: 2 info-level notes, no errors
- Test: 105 tests pass (102 existing + 3 new)
- Document: auto-fixed AGENTS.md to include agent-working event docs
- Lint: passed