### PR TITLE
fix(server): track agent presence across polling states

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,8 +47,10 @@ State lives at `~/.lavish-axi/state.json` (override with `LAVISH_AXI_STATE_DIR`)
 3. The artifact route reads the HTML from disk and runs `injectLavishSdk` (`src/html-transform.js`) to append `<script src="/sdk.js?key=...">` and, unless the artifact opts out with `<meta name="lavish-design" content="off">`, inject `/design/daisyui.css`, `/design/tailwindcss-browser.js`, and `/design/daisyui-themes.css`.
 4. Sibling assets resolve under `/artifact/:key/<path>`, sandboxed to the artifact's directory (`resolveArtifactAsset` rejects paths that escape via `..`), while packaged Tailwind/DaisyUI assets are served from `/design/:asset`.
 5. User actions in the iframe `postMessage` to the chrome (queue prompts, request snapshot, end session). The chrome POSTs collected prompts to `/api/:key/prompts`, which queues them in the session store and emits a `feedback` event. Text selection prompts use `tag: "text"` and preserve a structured `target` with `type: "text-range"`, selected text, `commonAncestorSelector`, and start/end boundary anchors.
-6. `lavish-axi poll <file.html>` (`pollCommand`) hits `GET /api/poll`. If queued prompts exist, it returns immediately; otherwise it long-polls on an `EventEmitter` until a `feedback` or `ended` event fires (default: no timeout - `--timeout-ms` is a test escape hatch).
-7. `--agent-reply` posts a chat message into the session before polling, so the agent's reply renders in the browser conversation panel via the `/events/:key` SSE stream.
+6. `lavish-axi poll <file.html>` (`pollCommand`) hits `GET /api/poll`. If queued prompts exist, it records that an agent has observed the session and returns immediately; otherwise it marks the session as actively listening and long-polls on an `EventEmitter` until a `feedback` or `ended` event fires (default: no timeout - `--timeout-ms` is a test escape hatch).
+7. The `/events/:key` SSE stream emits `agent-presence` states: `waiting` before any poll has attached, `listening` while a poll is active, and `working` after a poll has delivered feedback and released.
+   The chrome uses this state to show the waiting banner, allow queued feedback while waiting or listening, and block sends only while working.
+8. `--agent-reply` posts a chat message into the session before polling, so the agent's reply renders in the browser conversation panel via the `/events/:key` SSE stream.
 
 ### Live reload
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ pnpm link
 - **File-path identity** - Sessions are keyed by the canonical HTML file path, so agents do not need opaque IDs.
 - **Sandboxed artifact** - The artifact runs in an iframe while Lavish injects a small SDK for annotations, snapshots, and feedback controls, plus Tailwind CSS v4 and DaisyUI v5 design assets unless the HTML includes `<meta name="lavish-design" content="off">`.
 - **Feedback controls** - Mark buttons, choices, and other interactive elements with `data-lavish-action` so Lavish does not annotate them, then call `window.lavish.queuePrompt()` or `window.lavish.sendQueuedPrompts()` from the control handler.
+- **Agent presence** - The browser shows when no agent is listening, still queues feedback for the next `lavish-axi poll`, and only blocks sending while the agent is working on delivered feedback.
 - **Precise targets** - Text annotations include selected text plus range anchors, so agents are not limited to whole-element selectors.
 - **Local-first state** - Session state stays under `.lavish-axi/` in the workspace.
 

--- a/src/chrome-client.js
+++ b/src/chrome-client.js
@@ -14,10 +14,11 @@ const annotationButton = /** @type {HTMLButtonElement} */ (document.getElementBy
 const endButton = /** @type {HTMLButtonElement} */ (document.getElementById("end"));
 const filePathInput = /** @type {HTMLInputElement} */ (document.getElementById("filePath"));
 const copyPathButton = /** @type {HTMLButtonElement} */ (document.getElementById("copyPath"));
+const presenceBanner = /** @type {HTMLDivElement} */ (document.getElementById("presenceBanner"));
 
 const queued = [];
 let annotation = true;
-let agentPolling = false;
+let agentPresence = "waiting";
 let pendingSnapshot = "";
 let workingBubble = null;
 
@@ -81,11 +82,12 @@ function syncChat(chat) {
   chatLog.scrollTop = chatLog.scrollHeight;
 }
 
-function setAgentPolling(active) {
-  agentPolling = !!active;
-  sendButton.disabled = !agentPolling;
+function setAgentPresence(state) {
+  agentPresence = state === "listening" || state === "working" ? state : "waiting";
+  sendButton.disabled = agentPresence === "working";
+  if (presenceBanner) presenceBanner.hidden = agentPresence !== "waiting";
 
-  if (agentPolling) {
+  if (agentPresence !== "working") {
     if (workingBubble) workingBubble.remove();
     workingBubble = null;
     return;
@@ -111,7 +113,7 @@ function postToFrame(message) {
 }
 
 function sendQueued() {
-  if (!agentPolling) return;
+  if (agentPresence === "working") return;
 
   const text = chatInput.value.trim();
   if (text) {
@@ -128,7 +130,7 @@ function sendQueued() {
 async function submitQueued() {
   const prompts = queued.splice(0, queued.length);
   render();
-  setAgentPolling(false);
+  if (agentPresence === "listening") setAgentPresence("working");
   await fetch("/api/" + key + "/prompts", {
     method: "POST",
     headers: { "content-type": "application/json" },
@@ -214,8 +216,8 @@ events.addEventListener("reload", () => {
 events.addEventListener("chrome-reload", () => reloadAfterServerRestart());
 events.addEventListener("agent-reply", (event) => addChat("agent", JSON.parse(event.data).text));
 events.addEventListener("chat-sync", (event) => syncChat(JSON.parse(event.data).chat || []));
-events.addEventListener("agent-working", (event) => setAgentPolling(!JSON.parse(event.data).working));
+events.addEventListener("agent-presence", (event) => setAgentPresence(JSON.parse(event.data).state));
 
 render();
 initialChat.forEach((item) => addChat(item.role, item.text));
-setAgentPolling(false);
+setAgentPresence("waiting");

--- a/src/chrome.css
+++ b/src/chrome.css
@@ -359,6 +359,19 @@ body.lavish {
   flex-shrink: 0;
   box-sizing: border-box;
 }
+.presence-banner {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-elevated);
+  color: var(--fg-muted);
+  font-size: 11px;
+  font-weight: var(--w-medium);
+  line-height: 1.4;
+  padding: 8px 10px;
+}
+.presence-banner[hidden] {
+  display: none;
+}
 .annotation-pills {
   display: flex;
   flex-wrap: wrap;

--- a/src/server.js
+++ b/src/server.js
@@ -96,10 +96,13 @@ export async function serve({ port, stateFile, version = "" }) {
       const respond = async () => {
         if (responding || res.headersSent) return;
         responding = true;
-        const result = await store.takeFeedback(key);
-        if (result.status === "feedback") markFeedbackDelivered(key, activePolls, deliveredFeedback, events);
-        cleanup();
-        res.json(result);
+        try {
+          const result = await store.takeFeedback(key);
+          if (result.status === "feedback") markFeedbackDelivered(key, activePolls, deliveredFeedback, events);
+          res.json(result);
+        } finally {
+          cleanup();
+        }
       };
       const onFeedback = (changedKey) => {
         if (changedKey !== key || res.headersSent) {

--- a/src/server.js
+++ b/src/server.js
@@ -35,7 +35,7 @@ export async function serve({ port, stateFile, version = "" }) {
   const events = new EventEmitter();
   const watchers = new Map();
   const activePolls = new Map();
-  const pollHistory = new Set();
+  const deliveredFeedback = new Set();
   const sseClients = new Set();
 
   app.use(express.json({ limit: "2mb" }));
@@ -76,33 +76,35 @@ export async function serve({ port, stateFile, version = "" }) {
         req.query.timeoutMs === undefined ? null : Math.max(0, Math.min(Number(req.query.timeoutMs || 0), 2147483647));
       const immediate = await store.takeFeedback(key);
       if (immediate.status !== "waiting") {
-        markPollObserved(key, activePolls, pollHistory, events);
+        if (immediate.status === "feedback") markFeedbackDelivered(key, activePolls, deliveredFeedback, events);
         res.json(immediate);
         return;
       }
-      setPollActive(key, activePolls, pollHistory, events, true);
-      const timer =
-        timeoutMs === null
-          ? null
-          : setTimeout(async () => {
-              cleanup();
-              res.json(await store.takeFeedback(key));
-            }, timeoutMs);
-      const onFeedback = async (changedKey) => {
-        if (changedKey !== key || res.headersSent) {
-          return;
-        }
-        cleanup();
-        res.json(await store.takeFeedback(key));
-      };
+      setPollActive(key, activePolls, deliveredFeedback, events, true);
+      const timer = timeoutMs === null ? null : setTimeout(() => respond().catch(next), timeoutMs);
       let cleaned = false;
+      let responding = false;
       const cleanup = () => {
         if (cleaned) return;
         cleaned = true;
         if (timer) clearTimeout(timer);
         events.off("feedback", onFeedback);
         events.off("ended", onFeedback);
-        setPollActive(key, activePolls, pollHistory, events, false);
+        setPollActive(key, activePolls, deliveredFeedback, events, false);
+      };
+      const respond = async () => {
+        if (responding || res.headersSent) return;
+        responding = true;
+        const result = await store.takeFeedback(key);
+        if (result.status === "feedback") markFeedbackDelivered(key, activePolls, deliveredFeedback, events);
+        cleanup();
+        res.json(result);
+      };
+      const onFeedback = (changedKey) => {
+        if (changedKey !== key || res.headersSent) {
+          return;
+        }
+        respond().catch(next);
       };
       events.on("feedback", onFeedback);
       events.on("ended", onFeedback);
@@ -243,7 +245,7 @@ export async function serve({ port, stateFile, version = "" }) {
       };
       res.write(`event: chat-sync\ndata: ${JSON.stringify({ chat: session?.chat || [] })}\n\n`);
       res.write(
-        `event: agent-presence\ndata: ${JSON.stringify({ state: computePresence(req.params.key, activePolls, pollHistory) })}\n\n`,
+        `event: agent-presence\ndata: ${JSON.stringify({ state: computePresence(req.params.key, activePolls, deliveredFeedback) })}\n\n`,
       );
       events.on("reload", sendReload);
       events.on("agent-reply", sendAgentReply);
@@ -373,7 +375,8 @@ function watchSession(session, watchers, events) {
   watchers.set(session.key, watcher);
 }
 
-function setPollActive(key, activePolls, pollHistory, events, active) {
+function setPollActive(key, activePolls, deliveredFeedback, events, active) {
+  const previousPresence = computePresence(key, activePolls, deliveredFeedback);
   const count = activePolls.get(key) || 0;
   const nextCount = active ? count + 1 : Math.max(0, count - 1);
   if (nextCount === count) return;
@@ -381,24 +384,24 @@ function setPollActive(key, activePolls, pollHistory, events, active) {
     activePolls.delete(key);
   } else {
     activePolls.set(key, nextCount);
-    pollHistory.add(key);
+    deliveredFeedback.delete(key);
   }
-  if (count > 0 === nextCount > 0) return;
-  events.emit("agent-presence", key, computePresence(key, activePolls, pollHistory));
+  const nextPresence = computePresence(key, activePolls, deliveredFeedback);
+  if (nextPresence !== previousPresence) events.emit("agent-presence", key, nextPresence);
 }
 
-function markPollObserved(key, activePolls, pollHistory, events) {
-  const previousPresence = computePresence(key, activePolls, pollHistory);
-  pollHistory.add(key);
-  const nextPresence = computePresence(key, activePolls, pollHistory);
+function markFeedbackDelivered(key, activePolls, deliveredFeedback, events) {
+  const previousPresence = computePresence(key, activePolls, deliveredFeedback);
+  deliveredFeedback.add(key);
+  const nextPresence = computePresence(key, activePolls, deliveredFeedback);
   if (nextPresence !== previousPresence) {
     events.emit("agent-presence", key, nextPresence);
   }
 }
 
-export function computePresence(key, activePolls, pollHistory) {
+export function computePresence(key, activePolls, deliveredFeedback) {
   if (activePolls.has(key)) return "listening";
-  if (pollHistory.has(key)) return "working";
+  if (deliveredFeedback.has(key)) return "working";
   return "waiting";
 }
 
@@ -415,7 +418,7 @@ export function createChromeHtml(session) {
 </head>
 <body class="lavish">
 <div class="bar"><div class="brand"><span class="brand-mark">Lavish</span><span class="brand-support">Editor</span></div><div class="divider" aria-hidden="true"></div><div class="file-wrap" title="${escapeHtml(session.file)}"><input class="file-input" id="filePath" readonly size="${fileInputSize}" value="${escapeHtml(session.file)}"><button class="copy-button" id="copyPath" type="button">Copy Path</button></div><button class="button secondary annotation-on" id="annotation">Annotation: On</button><button class="button danger" id="end">End Session</button></div>
-<div class="layout"><div class="frame"><iframe id="artifact" sandbox="allow-scripts allow-forms allow-popups allow-downloads" src="/artifact/${session.key}/index.html"></iframe></div><aside class="panel"><h2>Conversation</h2><div class="chat" id="chatLog"></div><div class="composer"><div class="presence-banner" id="presenceBanner" hidden>No agent is listening - your message will be delivered when one attaches.</div><div class="annotation-pills" id="annotationPills"></div><textarea id="chatInput" placeholder="Write a message for the agent..."></textarea><div class="actions"><button class="button" id="send">Send to Agent</button></div></div></aside></div>
+<div class="layout"><div class="frame"><iframe id="artifact" sandbox="allow-scripts allow-forms allow-popups allow-downloads" src="/artifact/${session.key}/index.html"></iframe></div><aside class="panel"><h2>Conversation</h2><div class="chat" id="chatLog"></div><div class="composer"><div class="presence-banner" id="presenceBanner" hidden>Your agent is not listening. If this persists, ask your agent to poll for updates from Lavish.</div><div class="annotation-pills" id="annotationPills"></div><textarea id="chatInput" placeholder="Write a message for the agent..."></textarea><div class="actions"><button class="button" id="send">Send to Agent</button></div></div></aside></div>
 <script id="lavish-session" type="application/json">${sessionJson}</script>
 <script src="/chrome-client.js"></script>
 </body>

--- a/src/server.js
+++ b/src/server.js
@@ -76,6 +76,7 @@ export async function serve({ port, stateFile, version = "" }) {
         req.query.timeoutMs === undefined ? null : Math.max(0, Math.min(Number(req.query.timeoutMs || 0), 2147483647));
       const immediate = await store.takeFeedback(key);
       if (immediate.status !== "waiting") {
+        markPollObserved(key, activePolls, pollHistory, events);
         res.json(immediate);
         return;
       }
@@ -384,6 +385,15 @@ function setPollActive(key, activePolls, pollHistory, events, active) {
   }
   if (count > 0 === nextCount > 0) return;
   events.emit("agent-presence", key, computePresence(key, activePolls, pollHistory));
+}
+
+function markPollObserved(key, activePolls, pollHistory, events) {
+  const previousPresence = computePresence(key, activePolls, pollHistory);
+  pollHistory.add(key);
+  const nextPresence = computePresence(key, activePolls, pollHistory);
+  if (nextPresence !== previousPresence) {
+    events.emit("agent-presence", key, nextPresence);
+  }
 }
 
 export function computePresence(key, activePolls, pollHistory) {

--- a/src/server.js
+++ b/src/server.js
@@ -35,6 +35,7 @@ export async function serve({ port, stateFile, version = "" }) {
   const events = new EventEmitter();
   const watchers = new Map();
   const activePolls = new Map();
+  const pollHistory = new Set();
   const sseClients = new Set();
 
   app.use(express.json({ limit: "2mb" }));
@@ -78,7 +79,7 @@ export async function serve({ port, stateFile, version = "" }) {
         res.json(immediate);
         return;
       }
-      setPollActive(key, activePolls, events, true);
+      setPollActive(key, activePolls, pollHistory, events, true);
       const timer =
         timeoutMs === null
           ? null
@@ -100,7 +101,7 @@ export async function serve({ port, stateFile, version = "" }) {
         if (timer) clearTimeout(timer);
         events.off("feedback", onFeedback);
         events.off("ended", onFeedback);
-        setPollActive(key, activePolls, events, false);
+        setPollActive(key, activePolls, pollHistory, events, false);
       };
       events.on("feedback", onFeedback);
       events.on("ended", onFeedback);
@@ -234,21 +235,23 @@ export async function serve({ port, stateFile, version = "" }) {
           res.write(`event: agent-reply\ndata: ${JSON.stringify({ text })}\n\n`);
         }
       };
-      const sendWorking = (key, working) => {
+      const sendPresence = (key, state) => {
         if (key === req.params.key) {
-          res.write(`event: agent-working\ndata: ${JSON.stringify({ working })}\n\n`);
+          res.write(`event: agent-presence\ndata: ${JSON.stringify({ state })}\n\n`);
         }
       };
       res.write(`event: chat-sync\ndata: ${JSON.stringify({ chat: session?.chat || [] })}\n\n`);
-      res.write(`event: agent-working\ndata: ${JSON.stringify({ working: !activePolls.has(req.params.key) })}\n\n`);
+      res.write(
+        `event: agent-presence\ndata: ${JSON.stringify({ state: computePresence(req.params.key, activePolls, pollHistory) })}\n\n`,
+      );
       events.on("reload", sendReload);
       events.on("agent-reply", sendAgentReply);
-      events.on("agent-working", sendWorking);
+      events.on("agent-presence", sendPresence);
       req.on("close", () => {
         sseClients.delete(res);
         events.off("reload", sendReload);
         events.off("agent-reply", sendAgentReply);
-        events.off("agent-working", sendWorking);
+        events.off("agent-presence", sendPresence);
       });
     } catch (error) {
       next(error);
@@ -369,7 +372,7 @@ function watchSession(session, watchers, events) {
   watchers.set(session.key, watcher);
 }
 
-function setPollActive(key, activePolls, events, active) {
+function setPollActive(key, activePolls, pollHistory, events, active) {
   const count = activePolls.get(key) || 0;
   const nextCount = active ? count + 1 : Math.max(0, count - 1);
   if (nextCount === count) return;
@@ -377,9 +380,16 @@ function setPollActive(key, activePolls, events, active) {
     activePolls.delete(key);
   } else {
     activePolls.set(key, nextCount);
+    pollHistory.add(key);
   }
   if (count > 0 === nextCount > 0) return;
-  events.emit("agent-working", key, nextCount === 0);
+  events.emit("agent-presence", key, computePresence(key, activePolls, pollHistory));
+}
+
+export function computePresence(key, activePolls, pollHistory) {
+  if (activePolls.has(key)) return "listening";
+  if (pollHistory.has(key)) return "working";
+  return "waiting";
 }
 
 export function createChromeHtml(session) {
@@ -395,7 +405,7 @@ export function createChromeHtml(session) {
 </head>
 <body class="lavish">
 <div class="bar"><div class="brand"><span class="brand-mark">Lavish</span><span class="brand-support">Editor</span></div><div class="divider" aria-hidden="true"></div><div class="file-wrap" title="${escapeHtml(session.file)}"><input class="file-input" id="filePath" readonly size="${fileInputSize}" value="${escapeHtml(session.file)}"><button class="copy-button" id="copyPath" type="button">Copy Path</button></div><button class="button secondary annotation-on" id="annotation">Annotation: On</button><button class="button danger" id="end">End Session</button></div>
-<div class="layout"><div class="frame"><iframe id="artifact" sandbox="allow-scripts allow-forms allow-popups allow-downloads" src="/artifact/${session.key}/index.html"></iframe></div><aside class="panel"><h2>Conversation</h2><div class="chat" id="chatLog"></div><div class="composer"><div class="annotation-pills" id="annotationPills"></div><textarea id="chatInput" placeholder="Write a message for the agent..."></textarea><div class="actions"><button class="button" id="send">Send to Agent</button></div></div></aside></div>
+<div class="layout"><div class="frame"><iframe id="artifact" sandbox="allow-scripts allow-forms allow-popups allow-downloads" src="/artifact/${session.key}/index.html"></iframe></div><aside class="panel"><h2>Conversation</h2><div class="chat" id="chatLog"></div><div class="composer"><div class="presence-banner" id="presenceBanner" hidden>No agent is listening - your message will be delivered when one attaches.</div><div class="annotation-pills" id="annotationPills"></div><textarea id="chatInput" placeholder="Write a message for the agent..."></textarea><div class="actions"><button class="button" id="send">Send to Agent</button></div></div></aside></div>
 <script id="lavish-session" type="application/json">${sessionJson}</script>
 <script src="/chrome-client.js"></script>
 </body>

--- a/src/server.js
+++ b/src/server.js
@@ -60,8 +60,11 @@ export async function serve({ port, stateFile, version = "" }) {
       const file = await canonicalFile(req.body.file);
       const key = sessionKey(file);
       const url = `http://localhost:${port}/session/${key}`;
+      const existing = await store.findByKey(key);
       const session = await store.upsertSession(file, url);
-      clearFeedbackDelivery(key, activePolls, deliveredFeedback, events);
+      if (existing?.status === "ended") {
+        clearFeedbackDelivery(key, activePolls, deliveredFeedback, events);
+      }
       watchSession(session, watchers, events);
       res.json({ key, file, url, status: "opened" });
     } catch (error) {

--- a/src/server.js
+++ b/src/server.js
@@ -61,6 +61,7 @@ export async function serve({ port, stateFile, version = "" }) {
       const key = sessionKey(file);
       const url = `http://localhost:${port}/session/${key}`;
       const session = await store.upsertSession(file, url);
+      clearFeedbackDelivery(key, activePolls, deliveredFeedback, events);
       watchSession(session, watchers, events);
       res.json({ key, file, url, status: "opened" });
     } catch (error) {
@@ -131,6 +132,7 @@ export async function serve({ port, stateFile, version = "" }) {
   app.post("/api/:key/end", async (req, res, next) => {
     try {
       await store.endSession(req.params.key);
+      clearFeedbackDelivery(req.params.key, activePolls, deliveredFeedback, events);
       events.emit("ended", req.params.key);
       res.json({ status: "ended" });
     } catch (error) {
@@ -158,6 +160,7 @@ export async function serve({ port, stateFile, version = "" }) {
       const file = await canonicalFile(req.body.file);
       const key = sessionKey(file);
       await store.endSession(key);
+      clearFeedbackDelivery(key, activePolls, deliveredFeedback, events);
       events.emit("ended", key);
       res.json({ status: "ended" });
     } catch (error) {
@@ -393,6 +396,15 @@ function setPollActive(key, activePolls, deliveredFeedback, events, active) {
 function markFeedbackDelivered(key, activePolls, deliveredFeedback, events) {
   const previousPresence = computePresence(key, activePolls, deliveredFeedback);
   deliveredFeedback.add(key);
+  const nextPresence = computePresence(key, activePolls, deliveredFeedback);
+  if (nextPresence !== previousPresence) {
+    events.emit("agent-presence", key, nextPresence);
+  }
+}
+
+function clearFeedbackDelivery(key, activePolls, deliveredFeedback, events) {
+  const previousPresence = computePresence(key, activePolls, deliveredFeedback);
+  deliveredFeedback.delete(key);
   const nextPresence = computePresence(key, activePolls, deliveredFeedback);
   if (nextPresence !== previousPresence) {
     events.emit("agent-presence", key, nextPresence);

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -812,6 +812,53 @@ test("SSE agent-presence switches to working when poll immediately takes queued 
   }
 });
 
+test("SSE agent-presence resets to waiting after ending and reopening a session", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "lavish-serve-"));
+  const artifact = path.join(dir, "artifact.html");
+  await writeFile(artifact, "<!doctype html><html><body></body></html>");
+  const server = await serve({ port: 0, stateFile: path.join(dir, "state.json"), version: "9.9.9-test" });
+  try {
+    const base = `http://127.0.0.1:${server.port}`;
+    const open = await fetch(`${base}/api/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ file: artifact }),
+    });
+    const { key } = await open.json();
+    const presence = await startPresenceStream(base, key);
+    try {
+      assert.equal(await presence.next(), "waiting");
+
+      await fetch(`${base}/api/${key}/prompts`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ prompts: [{ prompt: "hello", tag: "message" }] }),
+      });
+      await fetch(`${base}/api/poll?file=${encodeURIComponent(artifact)}`);
+      assert.equal(await presence.next(), "working");
+
+      await fetch(`${base}/api/${key}/end`, { method: "POST" });
+      await fetch(`${base}/api/sessions`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ file: artifact }),
+      });
+    } finally {
+      await presence.close();
+    }
+
+    const reopenedPresence = await startPresenceStream(base, key);
+    try {
+      assert.equal(await reopenedPresence.next(), "waiting");
+    } finally {
+      await reopenedPresence.close();
+    }
+  } finally {
+    await server.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("ended session message renders centered in the main content area", async () => {
   const js = await chromeClientSource();
   const css = await chromeCssSource();

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -901,6 +901,45 @@ test("SSE agent-presence resets to waiting after ending and reopening a session"
   }
 });
 
+test("SSE agent-presence stays working when resuming an open session", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "lavish-serve-"));
+  const artifact = path.join(dir, "artifact.html");
+  await writeFile(artifact, "<!doctype html><html><body></body></html>");
+  const server = await serve({ port: 0, stateFile: path.join(dir, "state.json"), version: "9.9.9-test" });
+  try {
+    const base = `http://127.0.0.1:${server.port}`;
+    const open = await fetch(`${base}/api/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ file: artifact }),
+    });
+    const { key } = await open.json();
+
+    await fetch(`${base}/api/${key}/prompts`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ prompts: [{ prompt: "hello", tag: "message" }] }),
+    });
+    await fetch(`${base}/api/poll?file=${encodeURIComponent(artifact)}`);
+
+    await fetch(`${base}/api/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ file: artifact }),
+    });
+
+    const presence = await startPresenceStream(base, key);
+    try {
+      assert.equal(await presence.next(), "working");
+    } finally {
+      await presence.close();
+    }
+  } finally {
+    await server.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("ended session message renders centered in the main content area", async () => {
   const js = await chromeClientSource();
   const css = await chromeCssSource();

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -639,6 +639,81 @@ test("SSE handshake reports waiting on a fresh session that never had a poll", a
   }
 });
 
+test("SSE agent-presence switches to working when poll immediately takes queued feedback", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "lavish-serve-"));
+  const artifact = path.join(dir, "artifact.html");
+  await (await import("node:fs/promises")).writeFile(artifact, "<!doctype html><html><body></body></html>");
+  const server = await serve({ port: 0, stateFile: path.join(dir, "state.json"), version: "9.9.9-test" });
+  try {
+    const base = `http://127.0.0.1:${server.port}`;
+    const open = await fetch(`${base}/api/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ file: artifact }),
+    });
+    const { key } = await open.json();
+
+    const presenceEvents = [];
+    const presenceWaiters = [];
+    const presenceController = new AbortController();
+    const presenceFetch = fetch(`${base}/events/${key}`, { signal: presenceController.signal }).then(async (res) => {
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        let lines;
+        while ((lines = buffer.match(/^event: agent-presence\ndata: (.+)\n\n/m))) {
+          const data = JSON.parse(lines[1]);
+          presenceEvents.push(data.state);
+          buffer = buffer.replace(lines[0], "");
+          const waiter = presenceWaiters.shift();
+          if (waiter) waiter(data.state);
+        }
+      }
+    });
+    presenceFetch.catch(() => {});
+
+    const waitForPresence = () =>
+      new Promise((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error("timed out waiting for agent presence event")), 500);
+        if (presenceEvents.length > waitForPresence.lastIndex) {
+          waitForPresence.lastIndex++;
+          clearTimeout(timer);
+          resolve(presenceEvents[waitForPresence.lastIndex - 1]);
+          return;
+        }
+        presenceWaiters.push((state) => {
+          waitForPresence.lastIndex = presenceEvents.length;
+          clearTimeout(timer);
+          resolve(state);
+        });
+      });
+    waitForPresence.lastIndex = 0;
+
+    const initial = await waitForPresence();
+    assert.equal(initial, "waiting");
+
+    await fetch(`${base}/api/${key}/prompts`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ prompts: [{ prompt: "hello", tag: "message" }] }),
+    });
+    await fetch(`${base}/api/poll?file=${encodeURIComponent(artifact)}`);
+
+    const working = await waitForPresence();
+    assert.equal(working, "working");
+
+    presenceController.abort();
+    await presenceFetch.catch(() => {});
+  } finally {
+    await server.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("ended session message renders centered in the main content area", async () => {
   const js = await chromeClientSource();
   const css = await chromeCssSource();

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -19,6 +19,40 @@ function normalizeCssForAssertions(css) {
     .replace(/\s*([{}:;,])\s*/g, "$1")
     .replace(/\s+/g, " ")
     .replace(/0\./g, ".");
+}
+
+async function startPresenceStream(base, key) {
+  const controller = new AbortController();
+  const res = await fetch(`${base}/events/${key}`, { signal: controller.signal });
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  return {
+    async next() {
+      const deadline = Date.now() + 500;
+      while (true) {
+        const match = buffer.match(/^event: agent-presence\ndata: (.+)\n\n/m);
+        if (match) {
+          buffer = buffer.replace(match[0], "");
+          return JSON.parse(match[1]).state;
+        }
+        const remaining = Math.max(1, deadline - Date.now());
+        const { value, done } = await Promise.race([
+          reader.read(),
+          new Promise((_, reject) =>
+            setTimeout(() => reject(new Error("timed out waiting for agent presence event")), remaining),
+          ),
+        ]);
+        if (done) throw new Error("presence stream closed before an agent presence event");
+        buffer += decoder.decode(value, { stream: true });
+      }
+    },
+    async close() {
+      controller.abort();
+      await reader.cancel().catch(() => {});
+    },
+  };
 }
 
 test("server delegates artifact SDK generation to a dedicated source module", async () => {
@@ -356,7 +390,7 @@ test("chrome shows a waiting banner when no agent has attached", async () => {
   const css = await chromeCssSource();
 
   assert.match(html, /id="presenceBanner"/);
-  assert.match(html, /No agent is listening/);
+  assert.match(html, /Your agent is not listening/);
   assert.match(js, /presenceBanner\.hidden = agentPresence !== "waiting"/);
   assert.match(css, /\.presence-banner\{/);
 });
@@ -633,6 +667,70 @@ test("SSE handshake reports waiting on a fresh session that never had a poll", a
     }
     controller.abort();
     assert.equal(state, "waiting");
+  } finally {
+    await server.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("SSE agent-presence returns to waiting when a poll times out without feedback", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "lavish-serve-"));
+  const artifact = path.join(dir, "artifact.html");
+  await writeFile(artifact, "<!doctype html><html><body></body></html>");
+  const server = await serve({ port: 0, stateFile: path.join(dir, "state.json"), version: "9.9.9-test" });
+  try {
+    const base = `http://127.0.0.1:${server.port}`;
+    const open = await fetch(`${base}/api/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ file: artifact }),
+    });
+    const { key } = await open.json();
+    const presence = await startPresenceStream(base, key);
+    try {
+      assert.equal(await presence.next(), "waiting");
+
+      const poll = await fetch(`${base}/api/poll?file=${encodeURIComponent(artifact)}&timeoutMs=1`);
+      assert.deepEqual(await poll.json(), { status: "waiting" });
+
+      assert.equal(await presence.next(), "listening");
+      assert.equal(await presence.next(), "waiting");
+    } finally {
+      await presence.close();
+    }
+  } finally {
+    await server.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("SSE agent-presence returns to waiting when a poll disconnects without feedback", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "lavish-serve-"));
+  const artifact = path.join(dir, "artifact.html");
+  await writeFile(artifact, "<!doctype html><html><body></body></html>");
+  const server = await serve({ port: 0, stateFile: path.join(dir, "state.json"), version: "9.9.9-test" });
+  try {
+    const base = `http://127.0.0.1:${server.port}`;
+    const open = await fetch(`${base}/api/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ file: artifact }),
+    });
+    const { key } = await open.json();
+    const presence = await startPresenceStream(base, key);
+    try {
+      assert.equal(await presence.next(), "waiting");
+
+      const pollController = new AbortController();
+      const poll = fetch(`${base}/api/poll?file=${encodeURIComponent(artifact)}`, { signal: pollController.signal });
+      assert.equal(await presence.next(), "listening");
+      pollController.abort();
+      await poll.catch(() => {});
+
+      assert.equal(await presence.next(), "waiting");
+    } finally {
+      await presence.close();
+    }
   } finally {
     await server.close();
     await rm(dir, { recursive: true, force: true });

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -334,20 +334,31 @@ test("chrome can sync persisted chat after the event stream reconnects", async (
   assert.match(js, /function syncChat/);
 });
 
-test("chrome shows agent working state when no poll is active", async () => {
+test("chrome shows agent working state when a previous poll has released", async () => {
   const js = await chromeClientSource();
 
-  assert.match(js, /agent-working/);
+  assert.match(js, /agent-presence/);
   assert.match(js, /Working\.\.\./);
   assert.match(js, /spinner/);
 });
 
-test("chrome disables sending while agent is working", async () => {
+test("chrome disables sending while agent is working but allows it while waiting or listening", async () => {
   const js = await chromeClientSource();
 
-  assert.match(js, /let agentPolling = false/);
-  assert.match(js, /sendButton\.disabled = !agentPolling/);
-  assert.match(js, /if \(!agentPolling\) return/);
+  assert.match(js, /let agentPresence = "waiting"/);
+  assert.match(js, /sendButton\.disabled = agentPresence === "working"/);
+  assert.match(js, /if \(agentPresence === "working"\) return/);
+});
+
+test("chrome shows a waiting banner when no agent has attached", async () => {
+  const html = createChromeHtml({ key: "abc", file: "/tmp/artifact.html" });
+  const js = await chromeClientSource();
+  const css = await chromeCssSource();
+
+  assert.match(html, /id="presenceBanner"/);
+  assert.match(html, /No agent is listening/);
+  assert.match(js, /presenceBanner\.hidden = agentPresence !== "waiting"/);
+  assert.match(css, /\.presence-banner\{/);
 });
 
 test("chrome puts queued annotations inside the chat composer as preview pills", async () => {
@@ -513,6 +524,117 @@ test("POST /shutdown stops the listener so the client can spawn a fresh server",
     await server.done;
     await assert.rejects(() => fetch(`http://127.0.0.1:${server.port}/health`), /fetch failed|ECONNREFUSED/);
   } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("SSE agent-presence reflects waiting, listening, and working transitions", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "lavish-serve-"));
+  const artifact = path.join(dir, "artifact.html");
+  await (await import("node:fs/promises")).writeFile(artifact, "<!doctype html><html><body></body></html>");
+  const server = await serve({ port: 0, stateFile: path.join(dir, "state.json"), version: "9.9.9-test" });
+  try {
+    const base = `http://127.0.0.1:${server.port}`;
+    const open = await fetch(`${base}/api/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ file: artifact }),
+    });
+    const { key } = await open.json();
+
+    const presenceEvents = [];
+    const presenceWaiters = [];
+    const presenceController = new AbortController();
+    const presenceFetch = fetch(`${base}/events/${key}`, { signal: presenceController.signal }).then(async (res) => {
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        let lines;
+        while ((lines = buffer.match(/^event: agent-presence\ndata: (.+)\n\n/m))) {
+          const data = JSON.parse(lines[1]);
+          presenceEvents.push(data.state);
+          buffer = buffer.replace(lines[0], "");
+          const waiter = presenceWaiters.shift();
+          if (waiter) waiter(data.state);
+        }
+      }
+    });
+    presenceFetch.catch(() => {});
+
+    const waitForPresence = () =>
+      new Promise((resolve) => {
+        if (presenceEvents.length > waitForPresence.lastIndex) {
+          waitForPresence.lastIndex++;
+          resolve(presenceEvents[waitForPresence.lastIndex - 1]);
+          return;
+        }
+        presenceWaiters.push((state) => {
+          waitForPresence.lastIndex = presenceEvents.length;
+          resolve(state);
+        });
+      });
+    waitForPresence.lastIndex = 0;
+
+    const initial = await waitForPresence();
+    assert.equal(initial, "waiting", "first SSE handshake should report waiting before any poll");
+
+    const pollPromise = fetch(`${base}/api/poll?file=${encodeURIComponent(artifact)}`);
+    const listening = await waitForPresence();
+    assert.equal(listening, "listening", "should switch to listening when poll attaches");
+
+    await fetch(`${base}/api/${key}/prompts`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ prompts: [{ prompt: "hello", tag: "message" }] }),
+    });
+    await pollPromise;
+
+    const working = await waitForPresence();
+    assert.equal(working, "working", "should switch to working when poll releases after at least one attach");
+
+    presenceController.abort();
+    await presenceFetch.catch(() => {});
+  } finally {
+    await server.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("SSE handshake reports waiting on a fresh session that never had a poll", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "lavish-serve-"));
+  const artifact = path.join(dir, "artifact.html");
+  await (await import("node:fs/promises")).writeFile(artifact, "<!doctype html><html><body></body></html>");
+  const server = await serve({ port: 0, stateFile: path.join(dir, "state.json"), version: "9.9.9-test" });
+  try {
+    const base = `http://127.0.0.1:${server.port}`;
+    const open = await fetch(`${base}/api/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ file: artifact }),
+    });
+    const { key } = await open.json();
+
+    const controller = new AbortController();
+    const res = await fetch(`${base}/events/${key}`, { signal: controller.signal });
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    let state = null;
+    while (state === null) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const match = buffer.match(/^event: agent-presence\ndata: (.+)\n\n/m);
+      if (match) state = JSON.parse(match[1]).state;
+    }
+    controller.abort();
+    assert.equal(state, "waiting");
+  } finally {
+    await server.close();
     await rm(dir, { recursive: true, force: true });
   }
 });

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -737,6 +737,48 @@ test("SSE agent-presence returns to waiting when a poll disconnects without feed
   }
 });
 
+test("SSE agent-presence returns to waiting when poll feedback storage fails", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "lavish-serve-"));
+  const artifact = path.join(dir, "artifact.html");
+  const stateFile = path.join(dir, "state.json");
+  await writeFile(artifact, "<!doctype html><html><body></body></html>");
+  const server = await serve({ port: 0, stateFile, version: "9.9.9-test" });
+  try {
+    const base = `http://127.0.0.1:${server.port}`;
+    const open = await fetch(`${base}/api/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ file: artifact }),
+    });
+    const { key } = await open.json();
+    const presence = await startPresenceStream(base, key);
+    try {
+      assert.equal(await presence.next(), "waiting");
+
+      const poll = fetch(`${base}/api/poll?file=${encodeURIComponent(artifact)}&timeoutMs=10`);
+      assert.equal(await presence.next(), "listening");
+
+      await writeFile(stateFile, "not json");
+      const pollResult = await poll;
+      assert.equal(pollResult.status, 500);
+
+      assert.equal(await presence.next(), "waiting");
+    } finally {
+      await presence.close();
+    }
+  } finally {
+    await server.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("long-poll response cleanup is guarded against storage failures", async () => {
+  const source = await readFile(new URL("../src/server.js", import.meta.url), "utf8");
+
+  assert.match(source, /try \{\s*const result = await store\.takeFeedback\(key\)/);
+  assert.match(source, /finally \{\s*cleanup\(\);\s*\}/);
+});
+
 test("SSE agent-presence switches to working when poll immediately takes queued feedback", async () => {
   const dir = await mkdtemp(path.join(tmpdir(), "lavish-serve-"));
   const artifact = path.join(dir, "artifact.html");


### PR DESCRIPTION
## Intent

The developer wanted to create and iteratively refine a polished HyperFrames marketing video for Lavish Editor that follows the Lavish design system and accurately reflects the current product UI. The video needed to show an agent workflow from terminal prompt to Lavish Editor review, including chart annotation, batched feedback, a chat instruction to switch to dark mode, agent updates, and a clear outro using npx lavish-axi. They requested specific timing and animation refinements such as delaying explanatory panels, slowing terminal output, adding a pause before enter, zooming/panning during annotations, animating the Send to Agent button press, clearing submitted inputs, removing premature cursors, and holding the final result long enough to understand. They also wanted a design-token audit of the product surface and alignment between the marketing video and actual product copy and visual treatments. Finally, after approving the video, they wanted it embedded near the top of the README.

## What Changed

- Replaced the binary agent-working SSE signal with `agent-presence` states for `waiting`, `listening`, and `working`, including correct transitions for queued feedback, long-poll cleanup, ended sessions, and reopened sessions.
- Updated the browser chrome to show a waiting banner when no agent is listening, allow sending while waiting or listening, and only block sends while the agent is working on delivered feedback.
- Documented the new presence behavior and expanded server tests around SSE presence transitions, poll failures, session resume, and reopen flows.

## Risk Assessment

⚠️ Medium: The change is localized and covered by focused tests, but it touches long-poll/SSE presence state with subtle async lifecycle behavior.

## Testing

- Summary: Exercised the targeted server/chrome presence and long-polling tests plus the full existing test suite; all tests passed.
- `node --test test/server.test.js`
- `pnpm test`
- Outcome: ✅ passed across 1 run (1m12s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (3)</summary>

**Round 1** - found 1 warning
- ⚠️ `src/server.js:395` - `deliveredFeedback` is keyed only by the session key and is never cleared when the session is ended or reopened. After feedback is delivered, ending and reopening the same file in the same server process will make the fresh browser session receive `working`, which disables sending until another poll attaches.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `src/server.js:99` - If `store.takeFeedback(key)` rejects while a long poll is active, `cleanup()` is skipped because it only runs after the await succeeds. That leaves the poll counted in `activePolls` and its event listeners registered, so presence can stay stuck at `listening` after the request has already failed.

**Round 3** (auto-fix) - found 1 warning
- ⚠️ `src/server.js:64` - Opening an already-open session now always clears `deliveredFeedback`, so rerunning `lavish-axi &lt;file&gt;` while an agent is still working on previously delivered feedback makes SSE report `waiting` and re-enables browser sends. Limit this reset to genuinely ended/reopened sessions instead of every upsert/resume.

**Round 4** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `node --test test/server.test.js`
- `pnpm test`

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
