### PR TITLE
fix(cli): require agents to poll before replying

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -151,7 +151,7 @@ export function createPlaybookOutput(args) {
 export function createOpenOutput({ file, url, status }) {
   return {
     session: { file, url, status },
-    next_step: `Run \`lavish-axi poll ${file}\`. This command long-polls until the user sends feedback or ends the session. Do not pass --timeout-ms during normal agent use. Do not set a short shell timeout; either run it without a timeout or set the shell timeout above 10 minutes. After applying feedback, run \`lavish-axi poll ${file} --agent-reply "<message for the user>"\` without --timeout-ms to show your response in Lavish Editor and wait for more feedback.`,
+    next_step: `Do not respond to the user just yet. Now you must run \`lavish-axi poll ${file}\`. This command long-polls until the user sends feedback or ends the session. Do not pass --timeout-ms during normal agent use. Do not set a short shell timeout; either run it without a timeout or set the shell timeout above 10 minutes. After applying feedback, run \`lavish-axi poll ${file} --agent-reply "<message for the user>"\` without --timeout-ms to show your response in Lavish Editor and wait for more feedback.`,
   };
 }
 
@@ -207,7 +207,7 @@ export function createPollOutput({ file, response }) {
       session: { file, status: "feedback" },
       dom_snapshot: response.dom_snapshot || "",
       prompts: response.prompts || [],
-      next_step: `Apply the requested changes to ${file}, then run \`lavish-axi poll ${file} --agent-reply "<message for the user>"\` without --timeout-ms unless the user ended the session. The poll command waits until the user sends more feedback or ends the session; do not set a short shell timeout, or set the shell timeout above 10 minutes.`,
+      next_step: `Apply the requested changes to ${file}. Do not respond to the user just yet. Now you must run \`lavish-axi poll ${file} --agent-reply "<message for the user>"\` without --timeout-ms unless the user ended the session. The poll command waits until the user sends more feedback or ends the session; do not set a short shell timeout, or set the shell timeout above 10 minutes.`,
     };
   }
   if (response.status === "ended") {

--- a/test/cli-output.test.js
+++ b/test/cli-output.test.js
@@ -185,6 +185,7 @@ test("open output keeps the user URL in session data and next_step focused on po
   assert.equal(typeof output.next_step, "string");
   assert.doesNotMatch(output.next_step, /Tell the user/i);
   assert.doesNotMatch(output.next_step, /http:\/\/localhost:4387\/session\/abc123/);
+  assert.match(output.next_step, /Do not respond to the user just yet\. Now you must run/);
   assert.match(output.next_step, /lavish-axi poll \/tmp\/artifact\.html/);
   assert.match(output.next_step, /long-polls until/);
   assert.match(output.next_step, /do not set a short shell timeout/i);
@@ -210,6 +211,7 @@ test("feedback next step tells agents to keep polling without timeout flag", () 
 
   assert.match(output.next_step, /without --timeout-ms/);
   assert.match(output.next_step, /above 10 minutes/);
+  assert.match(output.next_step, /Do not respond to the user just yet\. Now you must run/);
 });
 
 test("html file arguments normalize to the hidden open command", () => {


### PR DESCRIPTION
## Intent

The developer wanted the AXI agent-facing response text strengthened so agents reliably poll for user input instead of replying prematurely. They specifically requested language like "Do not respond to user just yet. now you must..." because weaker poll guidance was sometimes being ignored. The change needed to affect the response that tells the agent to poll for user inputs.

## What Changed
- Strengthens `lavish-axi` open output so agents are explicitly told not to reply yet and to run `lavish-axi poll <file>` first.
- Updates feedback next-step guidance to require polling with `--agent-reply` after applying feedback instead of responding outside the Lavish loop.
- Adds CLI output assertions covering the stronger poll-before-reply wording.

## Risk Assessment

✅ Low: The branch only strengthens agent-facing polling guidance strings and updates focused assertions, with no behavioral server or polling logic changes.

## Testing

- Summary: Exercised the CLI output tests covering the strengthened open and feedback polling instructions; after installing missing locked dependencies, the focused tests passed.
- `node --test test/cli-output.test.js`
- Outcome: ✅ passed across 1 run (1m15s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `node --test test/cli-output.test.js`

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
