### PR TITLE
fix: harden feedback delivery edge cases

### DIFF
--- a/src/chrome-client.js
+++ b/src/chrome-client.js
@@ -21,6 +21,8 @@ let annotation = true;
 let agentPresence = "waiting";
 let pendingSnapshot = "";
 let workingBubble = null;
+let snapshotTimer = null;
+let sending = false;
 
 function escapeHtml(value) {
   return String(value).replace(
@@ -112,8 +114,20 @@ function postToFrame(message) {
   if (frame.contentWindow) frame.contentWindow.postMessage(message, "*");
 }
 
+function showSendError(message) {
+  if (presenceBanner) {
+    presenceBanner.textContent = message;
+    presenceBanner.hidden = false;
+  }
+}
+
+function clearSnapshotTimer() {
+  if (snapshotTimer) clearTimeout(snapshotTimer);
+  snapshotTimer = null;
+}
+
 function sendQueued() {
-  if (agentPresence === "working") return;
+  if (agentPresence === "working" || sending) return;
 
   const text = chatInput.value.trim();
   if (text) {
@@ -124,18 +138,33 @@ function sendQueued() {
   }
   if (!queued.length) return;
 
+  sending = true;
+  pendingSnapshot = "";
   postToFrame({ type: "lavish:requestSnapshot" });
+  snapshotTimer = setTimeout(() => submitQueued(""), 1000);
 }
 
-async function submitQueued() {
+async function submitQueued(snapshot = pendingSnapshot) {
+  if (!sending) return;
+  clearSnapshotTimer();
+  sending = false;
   const prompts = queued.splice(0, queued.length);
   render();
+  const previousPresence = agentPresence;
   if (agentPresence === "listening") setAgentPresence("working");
-  await fetch("/api/" + key + "/prompts", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ prompts, domSnapshot: pendingSnapshot }),
-  });
+  try {
+    const res = await fetch("/api/" + key + "/prompts", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ prompts, domSnapshot: snapshot }),
+    });
+    if (!res.ok) throw new Error("Send failed");
+  } catch {
+    queued.unshift(...prompts);
+    render();
+    setAgentPresence(previousPresence);
+    showSendError("Could not send feedback. Your queued prompts were restored; try again.");
+  }
 }
 
 async function endSession() {
@@ -189,7 +218,7 @@ window.addEventListener("message", (event) => {
   }
   if (msg.type === "lavish:snapshot") {
     pendingSnapshot = msg.snapshot || "";
-    submitQueued();
+    submitQueued(pendingSnapshot);
   }
   if (msg.type === "lavish:sendQueuedPrompts") sendQueued();
   if (msg.type === "lavish:endSession") endSession();

--- a/src/server.js
+++ b/src/server.js
@@ -128,6 +128,10 @@ export async function serve({ port, stateFile, version = "" }) {
         res.status(404).json({ error: "session not found" });
         return;
       }
+      if (session.ended) {
+        res.status(409).json({ error: "session ended" });
+        return;
+      }
       events.emit("feedback", req.params.key);
       res.json({ status: "queued", pending_prompts: session.pending_prompts });
     } catch (error) {
@@ -152,6 +156,10 @@ export async function serve({ port, stateFile, version = "" }) {
       const session = await store.addAgentReply(req.params.key, text);
       if (!session) {
         res.status(404).json({ error: "session not found" });
+        return;
+      }
+      if (session.ended) {
+        res.status(409).json({ error: "session ended" });
         return;
       }
       events.emit("agent-reply", req.params.key, text);
@@ -358,7 +366,13 @@ async function readDesignAsset(asset) {
 }
 
 export function resolveArtifactAsset(root, assetPath) {
-  const file = path.resolve(root, assetPath);
+  let decodedPath;
+  try {
+    decodedPath = decodeURIComponent(assetPath);
+  } catch {
+    return null;
+  }
+  const file = path.resolve(root, decodedPath);
   const relative = path.relative(root, file);
   if (relative.startsWith("..") || path.isAbsolute(relative)) {
     return null;

--- a/src/session-store.js
+++ b/src/session-store.js
@@ -50,6 +50,9 @@ export class SessionStore {
     if (!session) {
       return null;
     }
+    if (session.status === "ended") {
+      return { ended: true };
+    }
     const prompts = Array.isArray(payload.prompts) ? payload.prompts : [];
     const normalizedPrompts = prompts.map(normalizePrompt);
     const userMessages = normalizedPrompts
@@ -109,6 +112,9 @@ export class SessionStore {
     const session = state.sessions[key];
     if (!session) {
       return null;
+    }
+    if (session.status === "ended") {
+      return { ended: true };
     }
     session.chat = [...(session.chat || []), { role: "agent", text: String(text || ""), at: new Date().toISOString() }];
     session.updated_at = new Date().toISOString();

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -84,7 +84,10 @@ test("artifact assets resolve within the artifact directory", () => {
   const root = path.resolve("/tmp/lavish-artifact");
 
   assert.equal(resolveArtifactAsset(root, "style.css"), path.join(root, "style.css"));
+  assert.equal(resolveArtifactAsset(root, "nested/style.css"), path.join(root, "nested/style.css"));
   assert.equal(resolveArtifactAsset(root, "../secret.txt"), null);
+  assert.equal(resolveArtifactAsset(root, "%2e%2e/secret.txt"), null);
+  assert.equal(resolveArtifactAsset(root, "%E0%A4%A"), null);
 });
 
 test("chrome sandbox does not grant modal prompts", () => {
@@ -381,7 +384,24 @@ test("chrome disables sending while agent is working but allows it while waiting
 
   assert.match(js, /let agentPresence = "waiting"/);
   assert.match(js, /sendButton\.disabled = agentPresence === "working"/);
-  assert.match(js, /if \(agentPresence === "working"\) return/);
+  assert.match(js, /if \(agentPresence === "working" \|\| sending\) return/);
+});
+
+test("chrome preserves queued prompts when feedback send fails", async () => {
+  const js = await chromeClientSource();
+
+  assert.match(js, /const prompts = queued\.splice\(0, queued\.length\)/);
+  assert.match(js, /if \(!res\.ok\) throw new Error\("Send failed"\)/);
+  assert.match(js, /queued\.unshift\(\.\.\.prompts\)/);
+  assert.match(js, /Could not send feedback/);
+});
+
+test("chrome falls back when the artifact iframe does not return a snapshot", async () => {
+  const js = await chromeClientSource();
+
+  assert.match(js, /let snapshotTimer = null/);
+  assert.match(js, /snapshotTimer = setTimeout\(\(\) => submitQueued\(""\), 1000\)/);
+  assert.match(js, /clearSnapshotTimer\(\)/);
 });
 
 test("chrome shows a waiting banner when no agent has attached", async () => {

--- a/test/session-store.test.js
+++ b/test/session-store.test.js
@@ -85,6 +85,29 @@ test("ending a session makes feedback return ended", async () => {
   }
 });
 
+test("ended sessions reject queued prompts and agent replies", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "lavish-store-"));
+  try {
+    const stateFile = path.join(dir, "state.json");
+    const artifact = path.join(dir, "artifact.html");
+    await writeFile(artifact, "<h1>Hello</h1>");
+
+    const store = new SessionStore(stateFile);
+    const session = await store.upsertSession(artifact, "http://localhost:4387/session/test");
+    await store.endSession(session.key);
+
+    assert.deepEqual(await store.queuePrompts(session.key, { prompts: [{ prompt: "late" }] }), { ended: true });
+    assert.deepEqual(await store.addAgentReply(session.key, "Late reply"), { ended: true });
+
+    const updated = await store.findByKey(session.key);
+    assert.equal(updated.status, "ended");
+    assert.deepEqual(updated.prompts, []);
+    assert.deepEqual(updated.chat, []);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("agent replies are stored in session chat history", async () => {
   const dir = await mkdtemp(path.join(tmpdir(), "lavish-store-"));
   try {


### PR DESCRIPTION
## Summary

Hardens a few feedback/session edge cases in the Lavish Editor loop:

- preserve queued feedback if POST `/api/:key/prompts` fails
- fall back after 1s if the artifact iframe does not return a DOM snapshot
- reject stale prompt/reply writes after a session has ended
- decode artifact asset paths before resolving them, blocking encoded traversal/malformed encodings

## Why

These are small reliability fixes for the open → poll → user feedback → agent reply loop. The main user-visible problem is that feedback can appear queued locally but never safely reach the agent if the server/network/artifact frame misbehaves.

## Validation

- `npm run check`
- Tests: 115 passed, 0 failed
