### PR TITLE
fix(server): prevent live reload watcher stalls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,10 +54,12 @@ State lives at `~/.lavish-axi/state.json` (override with `LAVISH_AXI_STATE_DIR`)
 
 ### Live reload
 
-When a session opens, `chokidar` watches the artifact's directory (excluding `.git`, `node_modules`, `dist`, `build`, `.lavish-axi`).
+When a session opens, `chokidar` watches the artifact file itself by default - watching the entire parent directory recursively saturated the event loop when artifacts lived inside large trees like `~`.
+Artifacts can opt back into directory-wide live reload by adding `data-lavish-live-reload-root` to a root element or `<meta name="lavish-live-reload" content="root">`; that switches the watcher to the artifact's directory (excluding `.git`, `node_modules`, `dist`, `build`, `.lavish-axi`).
 Any file change emits a `reload` event, which the SSE endpoint pushes to the chrome page, which reloads the iframe.
 During version-driven shutdown, the server sends a `chrome-reload` SSE event so open browser chromes wait for the replacement server and then reload the whole chrome page.
 Hand-edited files in `dist/` won't trigger reloads.
+Run `lavish-axi server --verbose` (or set `LAVISH_AXI_DEBUG=1`) to log session and watcher events to stderr when diagnosing wedges.
 
 ### AXI integration
 

--- a/README.md
+++ b/README.md
@@ -118,11 +118,11 @@ Known playbook IDs: `diagram`, `table`, `comparison`, `plan`, `diff`, `input`, `
 
 ### Flags
 
-| Command                  | Flag                  | Description                                                               |
-| ------------------------ | --------------------- | ------------------------------------------------------------------------- |
-| `lavish-axi <html-file>` | `--no-open`           | Ensure the server/session exists without opening another browser window.  |
-| `lavish-axi poll`        | `--agent-reply "..."` | Show the agent's reply in the existing browser chat before polling again. |
-| `lavish-axi poll`        | `--timeout-ms <ms>`   | Test/debug escape hatch only; agents should normally omit it.             |
+| Command                  | Flag                  | Description                                                                              |
+| ------------------------ | --------------------- | ---------------------------------------------------------------------------------------- |
+| `lavish-axi <html-file>` | `--no-open`           | Ensure the server/session exists without opening another browser window.                 |
+| `lavish-axi poll`        | `--agent-reply "..."` | Show the agent's reply in the existing browser chat before polling again.                |
+| `lavish-axi poll`        | `--timeout-ms <ms>`   | Test/debug escape hatch only; agents should normally omit it.                            |
 | `lavish-axi server`      | `--verbose`           | Log session and watcher events to stderr; can also be enabled with `LAVISH_AXI_DEBUG=1`. |
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ pnpm link
 
 - **File-path identity** - Sessions are keyed by the canonical HTML file path, so agents do not need opaque IDs.
 - **Sandboxed artifact** - The artifact runs in an iframe while Lavish injects a small SDK for annotations, snapshots, and feedback controls, plus Tailwind CSS v4 and DaisyUI v5 design assets unless the HTML includes `<meta name="lavish-design" content="off">`.
+- **Live reload** - Lavish watches the HTML artifact file by default. To also reload on sibling asset changes, add `data-lavish-live-reload-root` to the root element or `<meta name="lavish-live-reload" content="root">`.
 - **Feedback controls** - Mark buttons, choices, and other interactive elements with `data-lavish-action` so Lavish does not annotate them, then call `window.lavish.queuePrompt()` or `window.lavish.sendQueuedPrompts()` from the control handler.
 - **Agent presence** - The browser shows when no agent is listening, still queues feedback for the next `lavish-axi poll`, and only blocks sending while the agent is working on delivered feedback.
 - **Precise targets** - Text annotations include selected text plus range anchors, so agents are not limited to whole-element selectors.
@@ -111,6 +112,7 @@ pnpm link
 | `lavish-axi end <html-file>`  | End a session.                                               |
 | `lavish-axi playbook [id]`    | List focused artifact guidance or show one playbook.         |
 | `lavish-axi design`           | Show the injected Tailwind CSS and DaisyUI design reference. |
+| `lavish-axi server`           | Run the local Lavish Editor server.                          |
 
 Known playbook IDs: `diagram`, `table`, `comparison`, `plan`, `diff`, `input`, `slides`.
 
@@ -121,6 +123,7 @@ Known playbook IDs: `diagram`, `table`, `comparison`, `plan`, `diff`, `input`, `
 | `lavish-axi <html-file>` | `--no-open`           | Ensure the server/session exists without opening another browser window.  |
 | `lavish-axi poll`        | `--agent-reply "..."` | Show the agent's reply in the existing browser chat before polling again. |
 | `lavish-axi poll`        | `--timeout-ms <ms>`   | Test/debug escape hatch only; agents should normally omit it.             |
+| `lavish-axi server`      | `--verbose`           | Log session and watcher events to stderr.                                 |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Known playbook IDs: `diagram`, `table`, `comparison`, `plan`, `diff`, `input`, `
 | `lavish-axi <html-file>` | `--no-open`           | Ensure the server/session exists without opening another browser window.  |
 | `lavish-axi poll`        | `--agent-reply "..."` | Show the agent's reply in the existing browser chat before polling again. |
 | `lavish-axi poll`        | `--timeout-ms <ms>`   | Test/debug escape hatch only; agents should normally omit it.             |
-| `lavish-axi server`      | `--verbose`           | Log session and watcher events to stderr.                                 |
+| `lavish-axi server`      | `--verbose`           | Log session and watcher events to stderr; can also be enabled with `LAVISH_AXI_DEBUG=1`. |
 
 ## Development
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -240,7 +240,8 @@ async function designCommand() {
 
 async function serverCommand(args) {
   const port = Number(flagValue(args, "--port") || defaultPort());
-  const server = await serve({ port, stateFile: stateFile(), version: VERSION });
+  const debug = args.includes("--verbose") || process.env.LAVISH_AXI_DEBUG === "1";
+  const server = await serve({ port, stateFile: stateFile(), version: VERSION, debug });
   await server.done;
   return "";
 }
@@ -453,7 +454,7 @@ const COMMAND_HELP = {
   end: `Usage: lavish-axi end <html-file>\n\nEnd a Lavish Editor session.\n`,
   playbook: `Usage: lavish-axi playbook [playbook_id]\n\nList focused artifact guidance playbooks, or show one playbook by ID. Known IDs: diagram, table, comparison, plan, diff, input, slides.\n\nExamples:\n  lavish-axi playbook\n  lavish-axi playbook diagram\n  lavish-axi playbook input\n`,
   design: `Usage: lavish-axi design\n\nShow technical reference for the Tailwind CSS browser runtime v4, DaisyUI v5 components, and DaisyUI themes that Lavish auto-injects into artifacts. Do not add these libraries separately.\n`,
-  server: `Usage: lavish-axi server [--port 4387]\n\nRun the local Lavish Editor server.\n`,
+  server: `Usage: lavish-axi server [--port 4387] [--verbose]\n\nRun the local Lavish Editor server. Pass --verbose (or set LAVISH_AXI_DEBUG=1) to log session and watcher events to stderr.\n`,
 };
 
 export { createDesignOutput };

--- a/src/server.js
+++ b/src/server.js
@@ -420,8 +420,9 @@ export async function resolveWatchTarget(session) {
 
 export function hasLiveReloadRootOptIn(html) {
   if (typeof html !== "string") return false;
-  if (/\bdata-lavish-live-reload-root\b/i.test(html)) return true;
-  return /<meta\b(?=[^>]*name=["']lavish-live-reload["'])(?=[^>]*content=["']root["'])[^>]*>/i.test(html);
+  const searchableHtml = html.replace(/<!--[\s\S]*?-->/g, "");
+  if (/<html\b[^>]*\sdata-lavish-live-reload-root(?:[\s=>/]|$)[^>]*>/i.test(searchableHtml)) return true;
+  return /<meta\b(?=[^>]*name=["']lavish-live-reload["'])(?=[^>]*content=["']root["'])[^>]*>/i.test(searchableHtml);
 }
 
 function setPollActive(key, activePolls, deliveredFeedback, events, active) {

--- a/src/server.js
+++ b/src/server.js
@@ -29,7 +29,7 @@ const designAssetUrls = {
   },
 };
 
-export async function serve({ port, stateFile, version = "" }) {
+export async function serve({ port, stateFile, version = "", debug = false, log = null }) {
   const app = express();
   const store = new SessionStore(stateFile);
   const events = new EventEmitter();
@@ -37,6 +37,9 @@ export async function serve({ port, stateFile, version = "" }) {
   const activePolls = new Map();
   const deliveredFeedback = new Set();
   const sseClients = new Set();
+  const verbose = debug || process.env.LAVISH_AXI_DEBUG === "1";
+  const writeLog = typeof log === "function" ? log : (line) => process.stderr.write(`${line}\n`);
+  const logEvent = verbose ? (line) => writeLog(`[lavish] ${line}`) : null;
 
   app.use(express.json({ limit: "2mb" }));
 
@@ -65,7 +68,8 @@ export async function serve({ port, stateFile, version = "" }) {
       if (existing?.status === "ended") {
         clearFeedbackDelivery(key, activePolls, deliveredFeedback, events);
       }
-      watchSession(session, watchers, events);
+      logEvent?.(`session opened key=${key} file=${file}`);
+      await watchSession(session, watchers, events, logEvent);
       res.json({ key, file, url, status: "opened" });
     } catch (error) {
       next(error);
@@ -181,7 +185,7 @@ export async function serve({ port, stateFile, version = "" }) {
         res.status(404).send("Session not found");
         return;
       }
-      watchSession(session, watchers, events);
+      await watchSession(session, watchers, events, logEvent);
       res.type("html").send(createChromeHtml(session));
     } catch (error) {
       next(error);
@@ -366,22 +370,58 @@ export function resolveArtifactAsset(root, assetPath) {
   return file;
 }
 
-function watchSession(session, watchers, events) {
+async function watchSession(session, watchers, events, logEvent) {
   if (watchers.has(session.key)) {
     return;
   }
-  const root = path.dirname(session.file);
-  const watcher = chokidar.watch(root, {
-    ignored: /(^|[/\\])(\.git|node_modules|dist|build|\.lavish-axi)([/\\]|$)/,
-    ignoreInitial: true,
-    awaitWriteFinish: { stabilityThreshold: 100, pollInterval: 50 },
-  });
+  const target = await resolveWatchTarget(session);
+  logEvent?.(`watch session=${session.key} scope=${target.scope} path=${target.path}`);
+  const watcher = chokidar.watch(target.path, target.options);
   let timer = null;
-  watcher.on("all", () => {
+  watcher.on("all", (event, file) => {
+    logEvent?.(`watch event=${event} session=${session.key} file=${file ?? ""}`);
     clearTimeout(timer);
     timer = setTimeout(() => events.emit("reload", session.key), 100);
   });
+  watcher.on("error", (error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    logEvent?.(`watch error session=${session.key} message=${message}`);
+  });
   watchers.set(session.key, watcher);
+}
+
+// Watching the artifact's parent directory recursively can stall the event loop when the
+// artifact lives in a large tree (e.g. ~/Downloads). Default to watching only the artifact
+// itself; an artifact opts back into directory-wide live reload via either a
+// `data-lavish-live-reload-root` attribute on its root element or
+// `<meta name="lavish-live-reload" content="root">`.
+export async function resolveWatchTarget(session) {
+  const baseOptions = {
+    ignoreInitial: true,
+    awaitWriteFinish: { stabilityThreshold: 100, pollInterval: 50 },
+  };
+  try {
+    const html = await readFile(session.file, "utf8");
+    if (hasLiveReloadRootOptIn(html)) {
+      return {
+        path: path.dirname(session.file),
+        scope: "directory",
+        options: {
+          ...baseOptions,
+          ignored: /(^|[/\\])(\.git|node_modules|dist|build|\.lavish-axi)([/\\]|$)/,
+        },
+      };
+    }
+  } catch {
+    // Fall through to file-only watching when the artifact can't be read.
+  }
+  return { path: session.file, scope: "file", options: baseOptions };
+}
+
+export function hasLiveReloadRootOptIn(html) {
+  if (typeof html !== "string") return false;
+  if (/\bdata-lavish-live-reload-root\b/i.test(html)) return true;
+  return /<meta\b(?=[^>]*name=["']lavish-live-reload["'])(?=[^>]*content=["']root["'])[^>]*>/i.test(html);
 }
 
 function setPollActive(key, activePolls, deliveredFeedback, events, active) {

--- a/src/server.js
+++ b/src/server.js
@@ -375,6 +375,9 @@ async function watchSession(session, watchers, events, logEvent) {
     return;
   }
   const target = await resolveWatchTarget(session);
+  if (watchers.has(session.key)) {
+    return;
+  }
   logEvent?.(`watch session=${session.key} scope=${target.scope} path=${target.path}`);
   const watcher = chokidar.watch(target.path, target.options);
   let timer = null;

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -956,6 +956,11 @@ test("hasLiveReloadRootOptIn detects the data attribute and meta opt-in", () => 
   );
 });
 
+test("hasLiveReloadRootOptIn ignores commented and text data attribute mentions", () => {
+  assert.equal(hasLiveReloadRootOptIn(`<!-- <html data-lavish-live-reload-root> -->`), false);
+  assert.equal(hasLiveReloadRootOptIn(`<html><body><code>data-lavish-live-reload-root</code></body></html>`), false);
+});
+
 test("resolveWatchTarget defaults to the artifact file so large sibling trees aren't scanned", async () => {
   const dir = await mkdtemp(path.join(tmpdir(), "lavish-watch-"));
   const artifact = path.join(dir, "artifact.html");

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -12,7 +12,7 @@ import {
   resolveWatchTarget,
   serve,
 } from "../src/server.js";
-import { sessionKey } from "../src/session-store.js";
+import { canonicalFile, sessionKey } from "../src/session-store.js";
 
 async function chromeClientSource() {
   return readFile(new URL("../src/chrome-client.js", import.meta.url), "utf8");
@@ -1092,6 +1092,7 @@ test("server debug logger receives session and watcher lifecycle events", async 
   const dir = await mkdtemp(path.join(tmpdir(), "lavish-debug-"));
   const artifact = path.join(dir, "artifact.html");
   await writeFile(artifact, "<!doctype html><html><body></body></html>");
+  const loggedArtifact = await canonicalFile(artifact);
   const logs = [];
   const server = await serve({
     port: 0,
@@ -1108,7 +1109,7 @@ test("server debug logger receives session and watcher lifecycle events", async 
       body: JSON.stringify({ file: artifact }),
     });
     assert.ok(
-      logs.some((line) => /session/i.test(line) && line.includes(artifact)),
+      logs.some((line) => /session/i.test(line) && line.includes(loggedArtifact)),
       `expected a session-opened log line, got: ${JSON.stringify(logs)}`,
     );
     assert.ok(

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -12,6 +12,7 @@ import {
   resolveWatchTarget,
   serve,
 } from "../src/server.js";
+import { sessionKey } from "../src/session-store.js";
 
 async function chromeClientSource() {
   return readFile(new URL("../src/chrome-client.js", import.meta.url), "utf8");
@@ -994,6 +995,54 @@ test("resolveWatchTarget falls back to file-only when the artifact can't be read
     key: "abc",
   });
   assert.equal(target.scope, "file");
+});
+
+test("concurrent same-session opens create only one file watcher", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "lavish-watch-race-"));
+  const artifact = path.join(dir, "artifact.html");
+  await writeFile(artifact, "<!doctype html><html><body>race</body></html>");
+  const key = sessionKey(artifact);
+  const stateFile = path.join(dir, "state.json");
+  await writeFile(
+    stateFile,
+    `${JSON.stringify({
+      sessions: {
+        [key]: {
+          key,
+          file: artifact,
+          url: `http://localhost:0/session/${key}`,
+          status: "open",
+          pending_prompts: 0,
+          prompts: [],
+          dom_snapshot: "",
+          chat: [],
+          updated_at: new Date().toISOString(),
+        },
+      },
+    })}\n`,
+  );
+  const logs = [];
+  const server = await serve({
+    port: 0,
+    stateFile,
+    version: "9.9.9-test",
+    debug: true,
+    log: (line) => logs.push(line),
+  });
+  try {
+    const base = `http://127.0.0.1:${server.port}`;
+    const responses = await Promise.all([
+      fetch(`${base}/session/${key}`),
+      fetch(`${base}/session/${key}`),
+    ]);
+    for (const response of responses) {
+      assert.equal(response.status, 200);
+    }
+    assert.equal(logs.filter((line) => line.includes("watch session=")).length, 1);
+  } finally {
+    await server.close();
+    await rm(dir, { recursive: true, force: true });
+  }
 });
 
 test("/health and / stay responsive after opening two back-to-back sessions", async () => {

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1031,10 +1031,7 @@ test("concurrent same-session opens create only one file watcher", async () => {
   });
   try {
     const base = `http://127.0.0.1:${server.port}`;
-    const responses = await Promise.all([
-      fetch(`${base}/session/${key}`),
-      fetch(`${base}/session/${key}`),
-    ]);
+    const responses = await Promise.all([fetch(`${base}/session/${key}`), fetch(`${base}/session/${key}`)]);
     for (const response of responses) {
       assert.equal(response.status, 200);
     }

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,10 +1,17 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { createChromeHtml, createSdkJs, resolveArtifactAsset, serve } from "../src/server.js";
+import {
+  createChromeHtml,
+  createSdkJs,
+  hasLiveReloadRootOptIn,
+  resolveArtifactAsset,
+  resolveWatchTarget,
+  serve,
+} from "../src/server.js";
 
 async function chromeClientSource() {
   return readFile(new URL("../src/chrome-client.js", import.meta.url), "utf8");
@@ -934,6 +941,129 @@ test("SSE agent-presence stays working when resuming an open session", async () 
     } finally {
       await presence.close();
     }
+  } finally {
+    await server.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("hasLiveReloadRootOptIn detects the data attribute and meta opt-in", () => {
+  assert.equal(hasLiveReloadRootOptIn("<html><body></body></html>"), false);
+  assert.equal(hasLiveReloadRootOptIn(`<html data-lavish-live-reload-root><body></body></html>`), true);
+  assert.equal(
+    hasLiveReloadRootOptIn(`<html><head><meta name="lavish-live-reload" content="root"></head></html>`),
+    true,
+  );
+});
+
+test("resolveWatchTarget defaults to the artifact file so large sibling trees aren't scanned", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "lavish-watch-"));
+  const artifact = path.join(dir, "artifact.html");
+  await writeFile(artifact, "<!doctype html><html><body></body></html>");
+  try {
+    const target = await resolveWatchTarget({ file: artifact, key: "abc" });
+    assert.equal(target.path, artifact);
+    assert.equal(target.scope, "file");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("resolveWatchTarget upgrades to the artifact directory when data-lavish-live-reload-root opts in", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "lavish-watch-"));
+  const artifact = path.join(dir, "artifact.html");
+  await writeFile(artifact, `<!doctype html><html data-lavish-live-reload-root><body></body></html>`);
+  try {
+    const target = await resolveWatchTarget({ file: artifact, key: "abc" });
+    assert.equal(target.path, dir);
+    assert.equal(target.scope, "directory");
+    assert.ok(target.options.ignored, "directory watch should ignore default noise");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("resolveWatchTarget falls back to file-only when the artifact can't be read", async () => {
+  const target = await resolveWatchTarget({
+    file: path.join(tmpdir(), `lavish-missing-artifact-${process.hrtime.bigint()}.html`),
+    key: "abc",
+  });
+  assert.equal(target.scope, "file");
+});
+
+test("/health and / stay responsive after opening two back-to-back sessions", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "lavish-back-to-back-"));
+  const a = path.join(dir, "a.html");
+  const b = path.join(dir, "b.html");
+  await writeFile(a, "<!doctype html><html><body>a</body></html>");
+  await writeFile(b, "<!doctype html><html><body>b</body></html>");
+  // Add a sibling tree so a recursive watcher would have to scan it.
+  const big = path.join(dir, "big");
+  await mkdir(big, { recursive: true });
+  await Promise.all(Array.from({ length: 40 }, (_, i) => writeFile(path.join(big, `file-${i}.txt`), "x".repeat(64))));
+  const server = await serve({ port: 0, stateFile: path.join(dir, "state.json"), version: "9.9.9-test" });
+  try {
+    const base = `http://127.0.0.1:${server.port}`;
+    await fetch(`${base}/api/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ file: a }),
+    });
+    await fetch(`${base}/api/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ file: b }),
+    });
+
+    const start = Date.now();
+    const healthRes = await Promise.race([
+      fetch(`${base}/health`),
+      new Promise((_, reject) => setTimeout(() => reject(new Error("/health timed out")), 1000)),
+    ]);
+    assert.equal(healthRes.status, 200);
+    assert.equal((await healthRes.json()).ok, true);
+
+    const rootRes = await Promise.race([
+      fetch(`${base}/`),
+      new Promise((_, reject) => setTimeout(() => reject(new Error("/ timed out")), 1000)),
+    ]);
+    assert.equal(rootRes.status, 404);
+    await rootRes.text().catch(() => {});
+
+    assert.ok(Date.now() - start < 1000, "both probes should return well under one second");
+  } finally {
+    await server.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("server debug logger receives session and watcher lifecycle events", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "lavish-debug-"));
+  const artifact = path.join(dir, "artifact.html");
+  await writeFile(artifact, "<!doctype html><html><body></body></html>");
+  const logs = [];
+  const server = await serve({
+    port: 0,
+    stateFile: path.join(dir, "state.json"),
+    version: "9.9.9-test",
+    debug: true,
+    log: (line) => logs.push(line),
+  });
+  try {
+    const base = `http://127.0.0.1:${server.port}`;
+    await fetch(`${base}/api/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ file: artifact }),
+    });
+    assert.ok(
+      logs.some((line) => /session/i.test(line) && line.includes(artifact)),
+      `expected a session-opened log line, got: ${JSON.stringify(logs)}`,
+    );
+    assert.ok(
+      logs.some((line) => /watch/i.test(line)),
+      `expected a watcher log line, got: ${JSON.stringify(logs)}`,
+    );
   } finally {
     await server.close();
     await rm(dir, { recursive: true, force: true });


### PR DESCRIPTION
## Intent

The developer wanted a maintainer-style triage of GitHub issue https://github.com/kunchenguid/lavish-axi/issues/30 using the provided managed checkout and any relevant GitHub context. They required structured JSON with one or more concrete resolution options, including comments, coding-agent handoff prompts, state changes, waiting-on ownership, and confidence. They emphasized not mutating GitHub or creating ad hoc clones, preferring actionable issues to be marked fix_required with a detailed multi-line handoff prompt, and surfacing multiple reasonable next steps when appropriate.

## What Changed

- Changes live reload to watch only the HTML artifact file by default, with explicit directory-wide opt-in via `data-lavish-live-reload-root` or `<meta name="lavish-live-reload" content="root">`.
- Adds server debug logging for session and watcher lifecycle events through `lavish-axi server --verbose` or `LAVISH_AXI_DEBUG=1`, and documents the new live reload behavior and diagnostics.
- Expands server tests for file-only watching, opt-in detection, concurrent watcher races, responsiveness after back-to-back sessions, and debug logging.

## Risk Assessment

✅ Low: The change is narrowly scoped to live-reload watcher selection and debug logging, with opt-in coverage for the previous directory-watch behavior and no material risks found in the changed code.

## Testing

- Summary: Exercised the changed live-reload watcher behavior, back-to-back session responsiveness, verbose watcher logging, and the updated server help output; all targeted tests passed.
- `node --test test/server.test.js`
- `node --test test/cli-output.test.js`
- `node bin/lavish-axi.js server --help`
- Outcome: ✅ passed across 1 run (46.7s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2)</summary>

**Round 1** - found 1 warning
- ⚠️ `src/server.js:423` - The directory-watch opt-in is detected by searching the entire raw HTML for `data-lavish-live-reload-root`, so a commented-out attribute or a code/documentation snippet containing that token will unintentionally switch the session back to recursive directory watching. That can reintroduce the event-loop saturation this branch is trying to avoid for artifacts placed in large directories; restrict detection to an actual start-tag attribute, ideally the intended root element, rather than any text occurrence.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `src/server.js:377` - `watchSession` now awaits `resolveWatchTarget` after checking `watchers.has(session.key)`, so two concurrent opens or `/session/:key` loads for the same artifact can both pass the guard, create separate chokidar watchers, and leave the overwritten watcher untracked. That leaks a watcher that `shutdown()` will not close and can duplicate reload events; re-check after the await or reserve the key before reading the artifact.

**Round 3** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `node --test test/server.test.js`
- `node --test test/cli-output.test.js`
- `node bin/lavish-axi.js server --help`

</details>

<details>
<summary>🔧 **Document** - 2 issues found → auto-fixed (2)</summary>

**Round 1** - found 2 issues (1 warning, 1 info)
- ⚠️ `README.md:97` - The change makes live reload watch only the artifact file by default and adds artifact-level opt-ins for directory-wide watching (`data-lavish-live-reload-root` or `&lt;meta name=&#34;lavish-live-reload&#34; content=&#34;root&#34;&gt;`). README is the packaged user-facing documentation, but its How It Works section does not document the new default or opt-in, leaving artifact authors without guidance when sibling CSS/JS/assets no longer trigger reloads.
- ℹ️ `README.md:117` - The CLI now exposes `lavish-axi server --verbose` and `LAVISH_AXI_DEBUG=1` for watcher/session diagnostics, and command help documents it. README&#39;s CLI Reference/Flags section is missing this new user-visible diagnostic option, so the packaged docs are incomplete for diagnosing the server wedge this change targets.

**Round 2** (auto-fix) - found 1 info
- ℹ️ `README.md:126` - The change adds `LAVISH_AXI_DEBUG=1` as a user-visible way to enable the same session and watcher diagnostics as `lavish-axi server --verbose`, and command help plus AGENTS.md mention it. README&#39;s CLI flags section documents only `--verbose`, so the packaged user-facing docs omit the new diagnostic environment variable.

**Round 3** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
