### PR TITLE
fix: harden feedback polling and queued prompts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,13 +41,13 @@ State lives at `~/.lavish-axi/state.json` (override with `LAVISH_AXI_STATE_DIR`)
 
 ### Request flow
 
-1. `lavish-axi <file.html>` (`openCommand`) -> POST `/api/sessions` -> `SessionStore.upsertSession` -> server returns `http://localhost:PORT/session/<key>` and the CLI calls `open` to launch the browser.
+1. `lavish-axi <file.html>` (`openCommand`) -> POST `/api/sessions` -> `SessionStore.upsertSession` -> server returns `http://127.0.0.1:PORT/session/<key>` and the CLI calls `open` to launch the browser.
 2. The browser loads `GET /session/:key`, which serves a chrome page (`createChromeHtml`) containing an iframe pointing at `/artifact/:key/index.html`, a stylesheet at `/chrome.css`, and browser behavior at `/chrome-client.js`.
    The chrome client reads its session bootstrap from the `lavish-session` JSON script in the page.
 3. The artifact route reads the HTML from disk and runs `injectLavishSdk` (`src/html-transform.js`) to append `<script src="/sdk.js?key=...">` at the end of `<body>`. Nothing else is injected - artifacts stay byte-identical (apart from the SDK script tag) so they remain portable when opened directly without the server.
 4. Sibling assets resolve under `/artifact/:key/<path>`, sandboxed to the artifact's directory (`resolveArtifactAsset` rejects paths that escape via `..`). The packaged Tailwind/DaisyUI assets are still served from `/design/:asset` so older artifacts that link them keep working, but new artifacts are no longer auto-wired to those routes.
-5. User actions in the iframe `postMessage` to the chrome (queue prompts, request snapshot, end session). The chrome POSTs collected prompts to `/api/:key/prompts`, which queues them in the session store and emits a `feedback` event. Text selection prompts use `tag: "text"` and preserve a structured `target` with `type: "text-range"`, selected text, `commonAncestorSelector`, and start/end boundary anchors.
-6. `lavish-axi poll <file.html>` (`pollCommand`) hits `GET /api/poll`. If queued prompts exist, it records that an agent has observed the session and returns immediately; otherwise it marks the session as actively listening and long-polls on an `EventEmitter` until a `feedback` or `ended` event fires (default: no timeout - `--timeout-ms` is a test escape hatch).
+5. User actions in the iframe `postMessage` to the chrome (queue prompts, request snapshot, end session). The chrome stores queued prompts in tab `sessionStorage`, POSTs collected prompts to `/api/:key/prompts`, removes them only after a successful response, queues them in the session store, and emits a `feedback` event. Text selection prompts use `tag: "text"` and preserve a structured `target` with `type: "text-range"`, selected text, `commonAncestorSelector`, and start/end boundary anchors.
+6. `lavish-axi poll <file.html>` (`pollCommand`) hits `GET /api/poll`. If queued prompts exist, it records that an agent has observed the session and returns immediately; otherwise it marks the session as actively listening and long-polls on an `EventEmitter` until a `feedback` or `ended` event fires. Default no-timeout polls stream whitespace heartbeat bytes before the final JSON response; `--timeout-ms` is a non-streaming test/debug escape hatch.
 7. The `/events/:key` SSE stream emits `agent-presence` states: `waiting` before any poll has attached, `listening` while a poll is active, and `working` after a poll has delivered feedback and released.
    The chrome uses this state to show the waiting banner, allow queued feedback while waiting or listening, and block sends only while working.
 8. `--agent-reply` posts a chat message into the session before polling, so the agent's reply renders in the browser conversation panel via the `/events/:key` SSE stream.
@@ -60,6 +60,7 @@ Any file change emits a `reload` event, which the SSE endpoint pushes to the chr
 During version-driven shutdown, the server sends a `chrome-reload` SSE event so open browser chromes wait for the replacement server and then reload the whole chrome page.
 Hand-edited files in `dist/` won't trigger reloads.
 Run `lavish-axi server --verbose` (or set `LAVISH_AXI_DEBUG=1`) to log session and watcher events to stderr when diagnosing wedges.
+Detached server stdout/stderr is also appended to `server.log` in `LAVISH_AXI_STATE_DIR` (default `~/.lavish-axi/server.log`) for startup and crash diagnostics.
 
 ### AXI integration
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ pnpm link
 - **Portable artifacts** - The artifact runs in an iframe while Lavish injects a small SDK for annotations, snapshots, and feedback controls. Lavish does not inject any design system, so the saved HTML file renders identically whether you open it through `lavish-axi` or directly in a browser. Run `lavish-axi design` for a copy-pasteable CDN snippet to opt in to Tailwind CSS v4 + DaisyUI v5, or use any other design system (or none).
 - **Live reload** - Lavish watches the HTML artifact file by default. To also reload on sibling asset changes, add `data-lavish-live-reload-root` to the root element or `<meta name="lavish-live-reload" content="root">`.
 - **Feedback controls** - Mark buttons, choices, and other interactive elements with `data-lavish-action` so Lavish does not annotate them, then call `window.lavish.queuePrompt()` or `window.lavish.sendQueuedPrompts()` from the control handler.
-- **Agent presence** - The browser shows when no agent is listening, still queues feedback for the next `lavish-axi poll`, and only blocks sending while the agent is working on delivered feedback.
+- **Agent presence** - The browser shows when no agent is listening, keeps queued feedback for the next successful `lavish-axi poll` send even across reloads, and only blocks sending while the agent is working on delivered feedback.
 - **Precise targets** - Text annotations include selected text plus range anchors, so agents are not limited to whole-element selectors.
 - **Local-first state** - Session state stays under `.lavish-axi/` in the workspace.
 
@@ -123,7 +123,7 @@ Known playbook IDs: `diagram`, `table`, `comparison`, `plan`, `diff`, `input`, `
 | `lavish-axi <html-file>` | `--no-open`           | Ensure the server/session exists without opening another browser window.                 |
 | `lavish-axi poll`        | `--agent-reply "..."` | Show the agent's reply in the existing browser chat before polling again.                |
 | `lavish-axi poll`        | `--timeout-ms <ms>`   | Test/debug escape hatch only; agents should normally omit it.                            |
-| `lavish-axi server`      | `--verbose`           | Log session and watcher events to stderr; can also be enabled with `LAVISH_AXI_DEBUG=1`. |
+| `lavish-axi server`      | `--verbose`           | Log session and watcher events to stderr; can also be enabled with `LAVISH_AXI_DEBUG=1`. Detached server output is appended to `~/.lavish-axi/server.log` (or `LAVISH_AXI_STATE_DIR/server.log`) for startup and crash diagnostics. |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -118,11 +118,11 @@ Known playbook IDs: `diagram`, `table`, `comparison`, `plan`, `diff`, `input`, `
 
 ### Flags
 
-| Command                  | Flag                  | Description                                                                              |
-| ------------------------ | --------------------- | ---------------------------------------------------------------------------------------- |
-| `lavish-axi <html-file>` | `--no-open`           | Ensure the server/session exists without opening another browser window.                 |
-| `lavish-axi poll`        | `--agent-reply "..."` | Show the agent's reply in the existing browser chat before polling again.                |
-| `lavish-axi poll`        | `--timeout-ms <ms>`   | Test/debug escape hatch only; agents should normally omit it.                            |
+| Command                  | Flag                  | Description                                                                                                                                                                                                                         |
+| ------------------------ | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `lavish-axi <html-file>` | `--no-open`           | Ensure the server/session exists without opening another browser window.                                                                                                                                                            |
+| `lavish-axi poll`        | `--agent-reply "..."` | Show the agent's reply in the existing browser chat before polling again.                                                                                                                                                           |
+| `lavish-axi poll`        | `--timeout-ms <ms>`   | Test/debug escape hatch only; agents should normally omit it.                                                                                                                                                                       |
 | `lavish-axi server`      | `--verbose`           | Log session and watcher events to stderr; can also be enabled with `LAVISH_AXI_DEBUG=1`. Detached server output is appended to `~/.lavish-axi/server.log` (or `LAVISH_AXI_STATE_DIR/server.log`) for startup and crash diagnostics. |
 
 ## Development

--- a/src/chrome-client.js
+++ b/src/chrome-client.js
@@ -3,6 +3,7 @@
 const sessionDataElement = document.getElementById("lavish-session");
 const sessionData = JSON.parse(sessionDataElement?.textContent || "{}");
 const key = String(sessionData.key || "");
+const queueStorageKey = "lavish-axi:queued:" + key;
 const initialChat = Array.isArray(sessionData.initialChat) ? sessionData.initialChat : [];
 
 const frame = /** @type {HTMLIFrameElement} */ (document.getElementById("artifact"));
@@ -16,7 +17,7 @@ const filePathInput = /** @type {HTMLInputElement} */ (document.getElementById("
 const copyPathButton = /** @type {HTMLButtonElement} */ (document.getElementById("copyPath"));
 const presenceBanner = /** @type {HTMLDivElement} */ (document.getElementById("presenceBanner"));
 
-const queued = [];
+const queued = loadQueuedPrompts();
 let annotation = true;
 let agentPresence = "waiting";
 let pendingSnapshot = "";
@@ -34,6 +35,27 @@ function escapeHtml(value) {
         "'": "&#39;",
       })[char],
   );
+}
+
+function loadQueuedPrompts() {
+  try {
+    const parsed = JSON.parse(sessionStorage.getItem(queueStorageKey) || "[]");
+    return Array.isArray(parsed) ? parsed.filter((prompt) => prompt && typeof prompt === "object") : [];
+  } catch {
+    return [];
+  }
+}
+
+function persistQueuedPrompts() {
+  try {
+    if (queued.length) {
+      sessionStorage.setItem(queueStorageKey, JSON.stringify(queued));
+    } else {
+      sessionStorage.removeItem(queueStorageKey);
+    }
+  } catch {
+    // The in-memory queue still works if browser storage is unavailable.
+  }
 }
 
 function render() {
@@ -105,6 +127,7 @@ function setAgentPresence(state) {
 function removeQueuedPrompt(index, event) {
   if (event) event.stopPropagation();
   queued.splice(index, 1);
+  persistQueuedPrompts();
   render();
 }
 
@@ -118,6 +141,7 @@ function sendQueued() {
   const text = chatInput.value.trim();
   if (text) {
     queued.push({ uid: "", prompt: text, selector: "", tag: "message", text: "Freeform message" });
+    persistQueuedPrompts();
     addChat("user", text);
     chatInput.value = "";
     render();
@@ -128,14 +152,17 @@ function sendQueued() {
 }
 
 async function submitQueued() {
-  const prompts = queued.splice(0, queued.length);
-  render();
-  if (agentPresence === "listening") setAgentPresence("working");
-  await fetch("/api/" + key + "/prompts", {
+  const prompts = queued.slice();
+  const response = await fetch("/api/" + key + "/prompts", {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ prompts, domSnapshot: pendingSnapshot }),
   });
+  if (!response.ok) throw new Error("failed to submit queued prompts");
+  queued.splice(0, prompts.length);
+  persistQueuedPrompts();
+  render();
+  if (agentPresence === "listening") setAgentPresence("working");
 }
 
 async function endSession() {
@@ -185,6 +212,7 @@ window.addEventListener("message", (event) => {
   const msg = event.data || {};
   if (msg.type === "lavish:queuePrompt") {
     queued.push(msg.prompt);
+    persistQueuedPrompts();
     render();
   }
   if (msg.type === "lavish:snapshot") {

--- a/src/chrome-client.js
+++ b/src/chrome-client.js
@@ -171,7 +171,10 @@ async function submitQueuedOnce() {
     body: JSON.stringify({ prompts, domSnapshot: pendingSnapshot }),
   });
   if (!response.ok) throw new Error("failed to submit queued prompts");
-  queued.splice(0, prompts.length);
+  for (const prompt of prompts) {
+    const index = queued.indexOf(prompt);
+    if (index !== -1) queued.splice(index, 1);
+  }
   persistQueuedPrompts();
   render();
   if (agentPresence === "listening") setAgentPresence("working");

--- a/src/chrome-client.js
+++ b/src/chrome-client.js
@@ -22,6 +22,7 @@ let annotation = true;
 let agentPresence = "waiting";
 let pendingSnapshot = "";
 let workingBubble = null;
+let submitQueuedPromise = null;
 
 function escapeHtml(value) {
   return String(value).replace(
@@ -152,6 +153,17 @@ function sendQueued() {
 }
 
 async function submitQueued() {
+  if (submitQueuedPromise) return submitQueuedPromise;
+
+  submitQueuedPromise = submitQueuedOnce();
+  try {
+    return await submitQueuedPromise;
+  } finally {
+    submitQueuedPromise = null;
+  }
+}
+
+async function submitQueuedOnce() {
   const prompts = queued.slice();
   const response = await fetch("/api/" + key + "/prompts", {
     method: "POST",

--- a/src/chrome-client.js
+++ b/src/chrome-client.js
@@ -23,6 +23,7 @@ let agentPresence = "waiting";
 let pendingSnapshot = "";
 let workingBubble = null;
 let submitQueuedPromise = null;
+let submitQueuedAgain = false;
 
 function escapeHtml(value) {
   return String(value).replace(
@@ -153,13 +154,22 @@ function sendQueued() {
 }
 
 async function submitQueued() {
-  if (submitQueuedPromise) return submitQueuedPromise;
+  if (submitQueuedPromise) {
+    submitQueuedAgain = true;
+    return submitQueuedPromise;
+  }
 
+  let succeeded = false;
   submitQueuedPromise = submitQueuedOnce();
   try {
-    return await submitQueuedPromise;
+    const result = await submitQueuedPromise;
+    succeeded = true;
+    return result;
   } finally {
     submitQueuedPromise = null;
+    const shouldSubmitAgain = submitQueuedAgain;
+    submitQueuedAgain = false;
+    if (succeeded && shouldSubmitAgain && queued.length) submitQueued();
   }
 }
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -505,7 +505,7 @@ const COMMAND_HELP = {
   end: `Usage: lavish-axi end <html-file>\n\nEnd a Lavish Editor session.\n`,
   playbook: `Usage: lavish-axi playbook [playbook_id]\n\nList focused artifact guidance playbooks, or show one playbook by ID. Known IDs: diagram, table, comparison, plan, diff, input, slides.\n\nExamples:\n  lavish-axi playbook\n  lavish-axi playbook diagram\n  lavish-axi playbook input\n`,
   design: `Usage: lavish-axi design\n\nShow a copy-pasteable CDN snippet for Tailwind CSS browser runtime v4 + DaisyUI v5 + themes, plus technical reference for DaisyUI components. Lavish artifacts stay portable HTML. Prefer the CDN snippet over hand-writing styles unless explicitly instructed otherwise by the user. If the user asks for another design system or plain HTML, follow that request.\n`,
-  server: `Usage: lavish-axi server [--port 4387] [--verbose]\n\nRun the local Lavish Editor server. Pass --verbose (or set LAVISH_AXI_DEBUG=1) to log session and watcher events to stderr.\n`,
+  server: `Usage: lavish-axi server [--port 4387] [--verbose]\n\nRun the local Lavish Editor server. Pass --verbose (or set LAVISH_AXI_DEBUG=1) to log session and watcher events to stderr. Detached server output is appended to ~/.lavish-axi/server.log, or LAVISH_AXI_STATE_DIR/server.log when set, for startup and crash diagnostics.\n`,
 };
 
 export { createDesignOutput };

--- a/src/cli.js
+++ b/src/cli.js
@@ -443,7 +443,11 @@ export async function fetchJson(url, { retries = 0, retryDelayMs = 250 } = {}) {
   if (!response.ok) {
     throw new AxiError(`Lavish Editor request failed: ${response.status}`, "SERVER_ERROR");
   }
-  return response.json();
+  try {
+    return await response.json();
+  } catch {
+    throw pollResponseInterruptedError();
+  }
 }
 
 async function postJson(url, body) {
@@ -465,6 +469,13 @@ async function postJson(url, body) {
 
 function serverConnectionError() {
   return new AxiError("Lavish Editor server connection failed", "SERVER_ERROR", [
+    "Run `lavish-axi server --verbose` to inspect server startup or crashes",
+    "Re-run the last `lavish-axi poll <html-file>` command after the server is healthy",
+  ]);
+}
+
+function pollResponseInterruptedError() {
+  return new AxiError("Lavish Editor poll response was interrupted", "SERVER_ERROR", [
     "Run `lavish-axi server --verbose` to inspect server startup or crashes",
     "Re-run the last `lavish-axi poll <html-file>` command after the server is healthy",
   ]);

--- a/src/cli.js
+++ b/src/cli.js
@@ -469,14 +469,14 @@ async function postJson(url, body) {
 
 function serverConnectionError() {
   return new AxiError("Lavish Editor server connection failed", "SERVER_ERROR", [
-    "Run `lavish-axi server --verbose` to inspect server startup or crashes",
+    "Run `lavish-axi server --verbose` or inspect `~/.lavish-axi/server.log` (`LAVISH_AXI_STATE_DIR/server.log` when set) for server startup or crash diagnostics",
     "Re-run the last `lavish-axi poll <html-file>` command after the server is healthy",
   ]);
 }
 
 function pollResponseInterruptedError() {
   return new AxiError("Lavish Editor poll response was interrupted", "SERVER_ERROR", [
-    "Run `lavish-axi server --verbose` to inspect server startup or crashes",
+    "Run `lavish-axi server --verbose` or inspect `~/.lavish-axi/server.log` (`LAVISH_AXI_STATE_DIR/server.log` when set) for server startup or crash diagnostics",
     "Re-run the last `lavish-axi poll <html-file>` command after the server is healthy",
   ]);
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,5 +1,5 @@
 import { spawn, spawnSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { closeSync, existsSync, openSync, readFileSync } from "node:fs";
 import { access } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -8,7 +8,7 @@ import { fileURLToPath } from "node:url";
 import { AxiError, runAxiCli } from "axi-sdk-js";
 
 import { createDesignOutput, DESIGN_SYSTEM_HINT } from "./design-reference.js";
-import { defaultPort, ensureStateDir, stateFile } from "./paths.js";
+import { defaultPort, ensureStateDir, LOOPBACK_HOST, serverLogFile, stateFile } from "./paths.js";
 import { findPlaybook, listPlaybooks, playbookIds } from "./playbooks.js";
 import { serve } from "./server.js";
 import { canonicalFile, sessionKey, SessionStore } from "./session-store.js";
@@ -192,7 +192,10 @@ async function pollCommand(args) {
   }
   const timeoutMs = flagValue(args, "--timeout-ms");
   const timeoutQuery = timeoutMs ? `&timeoutMs=${encodeURIComponent(timeoutMs)}` : "";
-  const response = await fetchJson(`${baseUrl}/api/poll?file=${encodeURIComponent(absolute)}${timeoutQuery}`);
+  const response = await fetchJson(`${baseUrl}/api/poll?file=${encodeURIComponent(absolute)}${timeoutQuery}`, {
+    retries: 3,
+    retryDelayMs: 500,
+  });
   return createPollOutput({ file: absolute, response });
 }
 
@@ -270,7 +273,7 @@ function isHtmlPath(file) {
 
 async function ensureServer({ forceRestart = false } = {}) {
   const port = defaultPort();
-  const baseUrl = `http://localhost:${port}`;
+  const baseUrl = `http://${LOOPBACK_HOST}:${port}`;
   const existing = await fetchHealth(baseUrl);
   if (existing && !shouldRestartServer(VERSION, existing, forceRestart)) {
     return baseUrl;
@@ -384,12 +387,18 @@ function killProcessOnPort(port) {
 async function startServer(port) {
   await ensureStateDir();
   const entry = resolveServerEntry();
-  const child = spawn(process.execPath, [entry, "server", "--port", String(port)], {
-    detached: true,
-    stdio: "ignore",
-    env: { ...process.env, LAVISH_AXI_NO_OPEN: "1" },
-  });
-  child.unref();
+  let logFd = null;
+  try {
+    logFd = openSync(serverLogFile(), "a");
+  } catch {
+    // If logging cannot be initialized, keep the server behavior unchanged.
+  }
+  try {
+    const child = spawn(process.execPath, [entry, "server", "--port", String(port)], createServerSpawnOptions(logFd));
+    child.unref();
+  } finally {
+    if (logFd !== null) closeSync(logFd);
+  }
 }
 
 // The detached server child must point at a node-executable entry that actually invokes
@@ -402,32 +411,61 @@ export function resolveServerEntry() {
   return fileURLToPath(import.meta.url);
 }
 
-export function createServerSpawnOptions() {
+/**
+ * @param {number | null} logFd
+ * @returns {import("node:child_process").SpawnOptions}
+ */
+export function createServerSpawnOptions(logFd = null) {
+  const stdio = /** @type {import("node:child_process").StdioOptions} */ (
+    logFd === null ? "ignore" : ["ignore", logFd, logFd]
+  );
   return {
     detached: true,
-    stdio: "ignore",
+    stdio,
     env: { ...process.env, LAVISH_AXI_NO_OPEN: "1" },
   };
 }
 
-async function fetchJson(url) {
-  const response = await fetch(url);
+export async function fetchJson(url, { retries = 0, retryDelayMs = 250 } = {}) {
+  for (let attempt = 0; attempt <= retries; attempt += 1) {
+    try {
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new AxiError(`Lavish Editor request failed: ${response.status}`, "SERVER_ERROR");
+      }
+      return await response.json();
+    } catch (error) {
+      if (error instanceof AxiError) throw error;
+      if (attempt >= retries) throw serverConnectionError();
+      await delay(retryDelayMs);
+    }
+  }
+
+  throw serverConnectionError();
+}
+
+async function postJson(url, body) {
+  let response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  } catch {
+    throw serverConnectionError();
+  }
   if (!response.ok) {
     throw new AxiError(`Lavish Editor request failed: ${response.status}`, "SERVER_ERROR");
   }
   return response.json();
 }
 
-async function postJson(url, body) {
-  const response = await fetch(url, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify(body),
-  });
-  if (!response.ok) {
-    throw new AxiError(`Lavish Editor request failed: ${response.status}`, "SERVER_ERROR");
-  }
-  return response.json();
+function serverConnectionError() {
+  return new AxiError("Lavish Editor server connection failed", "SERVER_ERROR", [
+    "Run `lavish-axi server --verbose` to inspect server startup or crashes",
+    "Re-run the last `lavish-axi poll <html-file>` command after the server is healthy",
+  ]);
 }
 
 function flagValue(args, flag) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -427,13 +427,11 @@ export function createServerSpawnOptions(logFd = null) {
 }
 
 export async function fetchJson(url, { retries = 0, retryDelayMs = 250 } = {}) {
+  let response;
   for (let attempt = 0; attempt <= retries; attempt += 1) {
     try {
-      const response = await fetch(url);
-      if (!response.ok) {
-        throw new AxiError(`Lavish Editor request failed: ${response.status}`, "SERVER_ERROR");
-      }
-      return await response.json();
+      response = await fetch(url);
+      break;
     } catch (error) {
       if (error instanceof AxiError) throw error;
       if (attempt >= retries) throw serverConnectionError();
@@ -441,7 +439,11 @@ export async function fetchJson(url, { retries = 0, retryDelayMs = 250 } = {}) {
     }
   }
 
-  throw serverConnectionError();
+  if (!response) throw serverConnectionError();
+  if (!response.ok) {
+    throw new AxiError(`Lavish Editor request failed: ${response.status}`, "SERVER_ERROR");
+  }
+  return response.json();
 }
 
 async function postJson(url, body) {

--- a/src/paths.js
+++ b/src/paths.js
@@ -2,6 +2,8 @@ import { mkdir } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
+export const LOOPBACK_HOST = "127.0.0.1";
+
 export function stateDir() {
   return process.env.LAVISH_AXI_STATE_DIR || path.join(os.homedir(), ".lavish-axi");
 }

--- a/src/server.js
+++ b/src/server.js
@@ -7,6 +7,7 @@ import express from "express";
 
 import { createArtifactSdk } from "./artifact-sdk.js";
 import { injectLavishSdk } from "./html-transform.js";
+import { LOOPBACK_HOST } from "./paths.js";
 import { canonicalFile, SessionStore, sessionKey } from "./session-store.js";
 
 const chromeClientUrl = new URL("./chrome-client.js", import.meta.url);
@@ -29,7 +30,7 @@ const designAssetUrls = {
   },
 };
 
-export async function serve({ port, stateFile, version = "", debug = false, log = null }) {
+export async function serve({ port, stateFile, version = "", debug = false, log = null, pollHeartbeatMs = 15_000 }) {
   const app = express();
   const store = new SessionStore(stateFile);
   const events = new EventEmitter();
@@ -40,6 +41,7 @@ export async function serve({ port, stateFile, version = "", debug = false, log 
   const verbose = debug || process.env.LAVISH_AXI_DEBUG === "1";
   const writeLog = typeof log === "function" ? log : (line) => process.stderr.write(`${line}\n`);
   const logEvent = verbose ? (line) => writeLog(`[lavish] ${line}`) : null;
+  let publicPort = port;
 
   app.use(express.json({ limit: "2mb" }));
 
@@ -62,7 +64,7 @@ export async function serve({ port, stateFile, version = "", debug = false, log 
     try {
       const file = await canonicalFile(req.body.file);
       const key = sessionKey(file);
-      const url = `http://localhost:${port}/session/${key}`;
+      const url = `http://${LOOPBACK_HOST}:${publicPort}/session/${key}`;
       const existing = await store.findByKey(key);
       const session = await store.upsertSession(file, url);
       if (existing?.status === "ended") {
@@ -88,6 +90,16 @@ export async function serve({ port, stateFile, version = "", debug = false, log 
         res.json(immediate);
         return;
       }
+      const streamHeartbeat = timeoutMs === null;
+      let heartbeat = null;
+      if (streamHeartbeat) {
+        res.status(200).type("application/json");
+        res.write(" ");
+        heartbeat = setInterval(() => {
+          if (!res.writableEnded) res.write(" ");
+        }, pollHeartbeatMs);
+        heartbeat.unref?.();
+      }
       setPollActive(key, activePolls, deliveredFeedback, events, true);
       const timer = timeoutMs === null ? null : setTimeout(() => respond().catch(next), timeoutMs);
       let cleaned = false;
@@ -96,23 +108,28 @@ export async function serve({ port, stateFile, version = "", debug = false, log 
         if (cleaned) return;
         cleaned = true;
         if (timer) clearTimeout(timer);
+        if (heartbeat) clearInterval(heartbeat);
         events.off("feedback", onFeedback);
         events.off("ended", onFeedback);
         setPollActive(key, activePolls, deliveredFeedback, events, false);
       };
       const respond = async () => {
-        if (responding || res.headersSent) return;
+        if (responding || res.writableEnded) return;
         responding = true;
         try {
           const result = await store.takeFeedback(key);
           if (result.status === "feedback") markFeedbackDelivered(key, activePolls, deliveredFeedback, events);
-          res.json(result);
+          if (streamHeartbeat) {
+            res.end(JSON.stringify(result));
+          } else {
+            res.json(result);
+          }
         } finally {
           cleanup();
         }
       };
       const onFeedback = (changedKey) => {
-        if (changedKey !== key || res.headersSent) {
+        if (changedKey !== key || res.writableEnded) {
           return;
         }
         respond().catch(next);
@@ -312,8 +329,9 @@ export async function serve({ port, stateFile, version = "", debug = false, log 
   });
 
   const httpServer = await new Promise((resolve) => {
-    const s = app.listen(port, "127.0.0.1", () => resolve(s));
+    const s = app.listen(port, LOOPBACK_HOST, () => resolve(s));
   });
+  publicPort = httpServer.address().port;
 
   let shuttingDown = false;
   function shutdown() {

--- a/src/server.js
+++ b/src/server.js
@@ -101,7 +101,7 @@ export async function serve({ port, stateFile, version = "", debug = false, log 
         heartbeat.unref?.();
       }
       setPollActive(key, activePolls, deliveredFeedback, events, true);
-      const timer = timeoutMs === null ? null : setTimeout(() => respond().catch(next), timeoutMs);
+      const timer = timeoutMs === null ? null : setTimeout(() => respond().catch(handleRespondError), timeoutMs);
       let cleaned = false;
       let responding = false;
       const cleanup = () => {
@@ -128,11 +128,19 @@ export async function serve({ port, stateFile, version = "", debug = false, log 
           cleanup();
         }
       };
+      function handleRespondError(error) {
+        if (streamHeartbeat) {
+          cleanup();
+          if (!res.writableEnded) res.destroy(error);
+          return;
+        }
+        next(error);
+      }
       const onFeedback = (changedKey) => {
         if (changedKey !== key || res.writableEnded) {
           return;
         }
-        respond().catch(next);
+        respond().catch(handleRespondError);
       };
       events.on("feedback", onFeedback);
       events.on("ended", onFeedback);

--- a/test/cli-output.test.js
+++ b/test/cli-output.test.js
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { createServer } from "node:http";
 import os from "node:os";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
@@ -16,6 +17,7 @@ import {
   createPollOutput,
   createPlaybookOutput,
   createServerSpawnOptions,
+  fetchJson,
   getCommandHelp,
   normalizeArgv,
   resolveServerEntry,
@@ -266,6 +268,13 @@ test("server spawn options detach without inheriting invalid streams", () => {
   assert.equal(options.stdio, "ignore");
 });
 
+test("server spawn options can persist detached server output to a log fd", () => {
+  const options = createServerSpawnOptions(17);
+
+  assert.equal(options.detached, true);
+  assert.deepEqual(options.stdio, ["ignore", 17, 17]);
+});
+
 test("server entry resolves to a node-executable script that actually invokes run()", () => {
   // Running from source, the entry must be `bin/lavish-axi.js` (the only file in the
   // source tree that calls run() on import). In the published bundle only `dist/cli.mjs`
@@ -354,4 +363,44 @@ test("polling a file without an active session tells the agent to open it first"
       return true;
     },
   );
+});
+
+test("network fetch failures become structured Lavish server errors", async () => {
+  await assert.rejects(
+    () => fetchJson("http://127.0.0.1:1/api/poll"),
+    (error) => {
+      assert.ok(error instanceof AxiError);
+      assert.equal(error.code, "SERVER_ERROR");
+      assert.match(error.message, /Lavish Editor server connection failed/);
+      assert.ok(error.suggestions.some((item) => item.includes("lavish-axi server --verbose")));
+      return true;
+    },
+  );
+});
+
+test("fetchJson retries transient connection failures", async () => {
+  let requests = 0;
+  const server = createServer((req, res) => {
+    requests += 1;
+    if (requests === 1) {
+      req.socket.destroy();
+      return;
+    }
+
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ status: "waiting" }));
+  });
+
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+  try {
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("test server did not bind to a TCP port");
+    const port = address.port;
+    const result = await fetchJson(`http://127.0.0.1:${port}/api/poll`, { retries: 1, retryDelayMs: 1 });
+
+    assert.deepEqual(result, { status: "waiting" });
+    assert.equal(requests, 2);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
 });

--- a/test/cli-output.test.js
+++ b/test/cli-output.test.js
@@ -404,3 +404,27 @@ test("fetchJson retries transient connection failures", async () => {
     await new Promise((resolve) => server.close(resolve));
   }
 });
+
+test("fetchJson does not retry response body parse failures", async () => {
+  let requests = 0;
+  const server = createServer((req, res) => {
+    requests += 1;
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end("{");
+  });
+
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+  try {
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("test server did not bind to a TCP port");
+    const port = address.port;
+
+    await assert.rejects(
+      () => fetchJson(`http://127.0.0.1:${port}/api/poll`, { retries: 1, retryDelayMs: 1 }),
+      SyntaxError,
+    );
+    assert.equal(requests, 1);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});

--- a/test/cli-output.test.js
+++ b/test/cli-output.test.js
@@ -405,7 +405,7 @@ test("fetchJson retries transient connection failures", async () => {
   }
 });
 
-test("fetchJson does not retry response body parse failures", async () => {
+test("fetchJson reports interrupted response body failures without retrying", async () => {
   let requests = 0;
   const server = createServer((req, res) => {
     requests += 1;
@@ -421,7 +421,12 @@ test("fetchJson does not retry response body parse failures", async () => {
 
     await assert.rejects(
       () => fetchJson(`http://127.0.0.1:${port}/api/poll`, { retries: 1, retryDelayMs: 1 }),
-      SyntaxError,
+      (error) => {
+        assert.ok(error instanceof AxiError);
+        assert.equal(error.code, "SERVER_ERROR");
+        assert.match(error.message, /Lavish Editor poll response was interrupted/);
+        return true;
+      },
     );
     assert.equal(requests, 1);
   } finally {

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -499,6 +499,14 @@ test("chrome keeps queued prompts persisted until submit succeeds", async () => 
   assert.match(js, /queued\.splice\(0, prompts\.length\);\s*persistQueuedPrompts\(\);/);
 });
 
+test("chrome ignores concurrent queued prompt submits", async () => {
+  const js = await chromeClientSource();
+
+  assert.match(js, /let submitQueuedPromise = null/);
+  assert.match(js, /if \(submitQueuedPromise\) return submitQueuedPromise/);
+  assert.match(js, /submitQueuedPromise = null/);
+});
+
 test("/health reports the server version so clients can detect upgrades", async () => {
   const dir = await mkdtemp(path.join(tmpdir(), "lavish-serve-"));
   const server = await serve({ port: 0, stateFile: path.join(dir, "state.json"), version: "9.9.9-test" });

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -496,7 +496,10 @@ test("chrome keeps queued prompts persisted until submit succeeds", async () => 
 
   assert.doesNotMatch(js, /const prompts = queued\.splice\(0, queued\.length\)/);
   assert.match(js, /await fetch\("\/api\/" \+ key \+ "\/prompts", \{/);
-  assert.match(js, /queued\.splice\(0, prompts\.length\);\s*persistQueuedPrompts\(\);/);
+  assert.doesNotMatch(js, /queued\.splice\(0, prompts\.length\)/);
+  assert.match(js, /for \(const prompt of prompts\) \{/);
+  assert.match(js, /const index = queued\.indexOf\(prompt\)/);
+  assert.match(js, /if \(index !== -1\) queued\.splice\(index, 1\)/);
 });
 
 test("chrome ignores concurrent queued prompt submits", async () => {

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -506,8 +506,18 @@ test("chrome ignores concurrent queued prompt submits", async () => {
   const js = await chromeClientSource();
 
   assert.match(js, /let submitQueuedPromise = null/);
-  assert.match(js, /if \(submitQueuedPromise\) return submitQueuedPromise/);
+  assert.match(js, /if \(submitQueuedPromise\) \{/);
+  assert.match(js, /return submitQueuedPromise/);
   assert.match(js, /submitQueuedPromise = null/);
+});
+
+test("chrome submits prompts queued during an in-flight submit", async () => {
+  const js = await chromeClientSource();
+
+  assert.match(js, /let submitQueuedAgain = false/);
+  assert.match(js, /submitQueuedAgain = true/);
+  assert.match(js, /const shouldSubmitAgain = submitQueuedAgain/);
+  assert.match(js, /if \(succeeded && shouldSubmitAgain && queued\.length\) submitQueued\(\)/);
 });
 
 test("/health reports the server version so clients can detect upgrades", async () => {
@@ -883,6 +893,15 @@ test("long-poll response cleanup is guarded against storage failures", async () 
 
   assert.match(source, /try \{\s*const result = await store\.takeFeedback\(key\)/);
   assert.match(source, /finally \{\s*cleanup\(\);\s*\}/);
+});
+
+test("heartbeat long-poll errors close the stream without Express error handling", async () => {
+  const source = await readFile(new URL("../src/server.js", import.meta.url), "utf8");
+
+  assert.match(source, /function handleRespondError\(error\) \{/);
+  assert.match(source, /if \(streamHeartbeat\) \{/);
+  assert.match(source, /res\.destroy\(error\)/);
+  assert.match(source, /respond\(\)\.catch\(handleRespondError\)/);
 });
 
 test("SSE agent-presence switches to working when poll immediately takes queued feedback", async () => {

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -482,6 +482,23 @@ test("chrome waits for the replacement server before version-driven reload", asy
   assert.match(js, /addEventListener\("chrome-reload", \(\) => reloadAfterServerRestart\(\)\)/);
 });
 
+test("chrome restores queued prompts from tab storage after reload", async () => {
+  const js = await chromeClientSource();
+
+  assert.match(js, /lavish-axi:queued:/);
+  assert.match(js, /function loadQueuedPrompts\(\)/);
+  assert.match(js, /const queued = loadQueuedPrompts\(\)/);
+  assert.match(js, /sessionStorage\.getItem\(queueStorageKey\)/);
+});
+
+test("chrome keeps queued prompts persisted until submit succeeds", async () => {
+  const js = await chromeClientSource();
+
+  assert.doesNotMatch(js, /const prompts = queued\.splice\(0, queued\.length\)/);
+  assert.match(js, /await fetch\("\/api\/" \+ key \+ "\/prompts", \{/);
+  assert.match(js, /queued\.splice\(0, prompts\.length\);\s*persistQueuedPrompts\(\);/);
+});
+
 test("/health reports the server version so clients can detect upgrades", async () => {
   const dir = await mkdtemp(path.join(tmpdir(), "lavish-serve-"));
   const server = await serve({ port: 0, stateFile: path.join(dir, "state.json"), version: "9.9.9-test" });
@@ -490,6 +507,74 @@ test("/health reports the server version so clients can detect upgrades", async 
     const body = await res.json();
     assert.equal(body.ok, true);
     assert.equal(body.version, "9.9.9-test");
+  } finally {
+    await server.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("session URLs use the same IPv4 loopback host the server binds", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "lavish-serve-"));
+  const artifact = path.join(dir, "artifact.html");
+  await writeFile(artifact, "<!doctype html><html><body></body></html>");
+  const server = await serve({ port: 0, stateFile: path.join(dir, "state.json"), version: "9.9.9-test" });
+  try {
+    const res = await fetch(`http://127.0.0.1:${server.port}/api/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ file: artifact }),
+    });
+    const body = await res.json();
+
+    assert.match(body.url, /^http:\/\/127\.0\.0\.1:/);
+    assert.doesNotMatch(body.url, /localhost/);
+  } finally {
+    await server.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("long-poll sends heartbeat bytes before feedback arrives", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "lavish-serve-"));
+  const artifact = path.join(dir, "artifact.html");
+  await writeFile(artifact, "<!doctype html><html><body></body></html>");
+  const server = await serve({
+    port: 0,
+    stateFile: path.join(dir, "state.json"),
+    version: "9.9.9-test",
+    pollHeartbeatMs: 10,
+  });
+  try {
+    const base = `http://127.0.0.1:${server.port}`;
+    await fetch(`${base}/api/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ file: artifact }),
+    });
+
+    const controller = new AbortController();
+    const res = await Promise.race([
+      fetch(`${base}/api/poll?file=${encodeURIComponent(artifact)}`, { signal: controller.signal }),
+      new Promise((_, reject) => setTimeout(() => reject(new Error("poll did not send headers")), 50)),
+    ]);
+    const reader = res.body.getReader();
+    try {
+      const decoder = new TextDecoder();
+      const first = await Promise.race([
+        reader.read(),
+        new Promise((_, reject) => setTimeout(() => reject(new Error("poll did not send initial heartbeat")), 50)),
+      ]);
+      const second = await Promise.race([
+        reader.read(),
+        new Promise((_, reject) => setTimeout(() => reject(new Error("poll did not repeat heartbeat")), 50)),
+      ]);
+
+      assert.equal(decoder.decode(first.value), " ");
+      assert.equal(decoder.decode(second.value), " ");
+    } finally {
+      controller.abort();
+      await reader.cancel().catch(() => {});
+    }
   } finally {
     await server.close();
     await rm(dir, { recursive: true, force: true });
@@ -624,7 +709,7 @@ test("SSE agent-presence reflects waiting, listening, and working transitions", 
     const initial = await waitForPresence();
     assert.equal(initial, "waiting", "first SSE handshake should report waiting before any poll");
 
-    const pollPromise = fetch(`${base}/api/poll?file=${encodeURIComponent(artifact)}`);
+    const pollPromise = fetch(`${base}/api/poll?file=${encodeURIComponent(artifact)}`).then((res) => res.json());
     const listening = await waitForPresence();
     assert.equal(listening, "listening", "should switch to listening when poll attaches");
 
@@ -730,7 +815,9 @@ test("SSE agent-presence returns to waiting when a poll disconnects without feed
       assert.equal(await presence.next(), "waiting");
 
       const pollController = new AbortController();
-      const poll = fetch(`${base}/api/poll?file=${encodeURIComponent(artifact)}`, { signal: pollController.signal });
+      const poll = fetch(`${base}/api/poll?file=${encodeURIComponent(artifact)}`, {
+        signal: pollController.signal,
+      }).then((res) => res.text());
       assert.equal(await presence.next(), "listening");
       pollController.abort();
       await poll.catch(() => {});


### PR DESCRIPTION
## Intent

{"summary":"The developer wanted to understand and prevent a Lavish AXI polling failure that refreshed the page and wiped queued browser feedback. They asked for the root cause of the error, preservation of queued feedback across reloads or failed sends, and then pushed for preventing the polling error itself rather than only mitigating data loss. They wanted obvious non-version-restart causes investigated, including long-poll fragility, localhost versus 127.0.0.1 mismatch, opaque detached server crashes, and missing retry behavior. They ultimately requested defenses for all identified risks: early/heartbeat poll responses, retrying transient poll connection failures, consistent loopback addressing, detached server logging, and tests verifying the behavior."}

## What Changed
- Persist queued browser feedback in tab session storage and keep prompts queued until `/api/:key/prompts` succeeds, with in-flight submit handling to avoid duplicate or lost sends.
- Make polling more resilient by streaming heartbeat bytes for default long polls, retrying only pre-response connection failures, and returning structured errors for interrupted poll responses.
- Use `127.0.0.1` consistently for local server URLs and add detached server stdout/stderr logging plus CLI and docs guidance for startup or crash diagnostics.

## Risk Assessment

✅ Low: The changes are well-bounded to feedback polling resilience, queued prompt preservation, and supporting tests, with no material correctness issues found in the reviewed diff.

## Testing

- Summary: Inspected the target diff, ran the focused server and CLI test files, corrected a manual harness parser issue, and successfully exercised the real CLI/server feedback path showing 127.0.0.1 session URLs, queued browser-style feedback, poll delivery with DOM snapshot, and post-poll server health.
<details>
<summary>Evidence: End-to-end CLI feedback polling transcript</summary>

```text
open session url: http://127.0.0.1:46434/session/ec66f17bf44fd0c9
browser-style queue response: 200 {"status":"queued","pending_prompts":1}
poll returned feedback: true
poll included prompt: true
poll included dom snapshot: true
health after poll: 200 {"ok":true,"app":"lavish-axi","version":"0.1.11"}
```
</details>
- Outcome: ✅ passed across 1 run (2m2s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (5)</summary>

**Round 1** - found 1 warning
- ⚠️ `src/chrome-client.js:155` - Keeping the queue intact until the POST succeeds allows concurrent submits to send the same snapshot of `queued` more than once. A double click on Send, or multiple `lavish:snapshot` messages before the first `/prompts` request resolves, will call `submitQueued()` twice with the same prompts and `SessionStore.queuePrompts()` appends duplicates with no dedupe. Add an in-flight guard or disable sending while a submit is pending, while still preserving the queue on failure.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `src/chrome-client.js:174` - After a successful submit, `queued.splice(0, prompts.length)` removes prompts by position rather than removing the exact snapshot that was posted. Because the UI leaves those pills editable while the request is in flight, a user can remove one of the sent prompts or add/reorder later prompts before the POST resolves; the success handler can then delete a different queued prompt from `sessionStorage` without ever sending it. Remove submitted entries by stable identity/reference or disable queue mutation while a submit is pending.

**Round 3** (auto-fix) - found 2 warnings
- ⚠️ `src/chrome-client.js:156` - While a queued prompt submit is in flight, later Send actions are collapsed into the existing promise. If the user adds another message or annotation and clicks Send before the first POST resolves, that new prompt remains in the local queue but the chat already shows it as a sent user message, so the agent will not receive it until the user notices and sends again. Disable send/queue mutation while `submitQueuedPromise` is active or schedule a follow-up submit for prompts added during the in-flight request.
- ⚠️ `src/server.js:97` - The heartbeat writes response headers before the long-poll result is available, but `respond()` still routes later `store.takeFeedback()` failures through Express error handling. Once headers have been sent, the error handler cannot return the existing structured 500 JSON and the client can see a terminated or hanging stream instead of the intended server error. Handle errors inside the streaming branch by ending/destroying the response after cleanup rather than calling `next()` after headers are sent.

**Round 4** (auto-fix) - found 1 warning
- ⚠️ `src/cli.js:436` - `fetchJson()` retries any non-`AxiError`, including failures while parsing or reading a 200 response body. For `/api/poll`, the server clears queued feedback before ending the response, so if the connection drops after `store.takeFeedback()` but before `response.json()` completes, the retry can return or hang on `waiting` and hide that feedback was already consumed. Limit retries to failures before an HTTP response is received, and surface body/JSON read failures instead of retrying destructive poll reads.

**Round 5** (auto-fix) - found 1 warning
- ⚠️ `src/cli.js:446` - `fetchJson()` now deliberately avoids retrying `response.json()` failures, but it also lets those body/JSON read failures escape as raw `SyntaxError`/`TypeError`. Because the new long-poll heartbeat sends response headers before final JSON, a server crash or interrupted stream during an otherwise normal poll will hit this path and lose the CLI&#39;s structured `AxiError` guidance. Catch body parsing/stream errors separately and throw a non-retrying `AxiError` that explains the poll response was interrupted.

**Round 6** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- <code>`git diff --stat 2d200d947692a7607adaec9481285de879933aea..ef2b4265f8190257e69cb695cf11f5169f199ba5` and `git diff --name-only 2d200d947692a7607adaec9481285de879933aea..ef2b4265f8190257e69cb695cf11f5169f199ba5` to understand the change scope before testing</code>
- `node --test test/server.test.js`
- `node --test test/cli-output.test.js`
- <code>`node --input-type=module - &lt;&lt;&#39;NODE&#39; ... NODE` end-to-end CLI/API check: created an isolated artifact and state dir, ran `bin/lavish-axi.js open --no-open`, posted prompts to `/api/:key/prompts`, ran `bin/lavish-axi.js poll --timeout-ms 2000`, checked `/health`, and shut the isolated server down</code>
- <code>Initial end-to-end harness attempt with the same `node --input-type=module` flow failed only because the parser did not account for quoted TOON URL output; it was corrected and rerun successfully</code>

</details>

<details>
<summary>🔧 **Document** - 6 issues found → auto-fixed (3)</summary>

**Round 1** - found 6 issues (3 warnings, 3 infos)
- ⚠️ `README.md:101` - The change makes queued browser feedback persist in tab sessionStorage and keeps it queued until a send succeeds, including across reloads or failed prompt submissions. The user-facing README only says feedback is queued while no agent is listening, so it should document the stronger reload/send-failure preservation behavior.
- ⚠️ `README.md:126` - The change adds persistent stdout/stderr capture for detached background server processes at the state directory&#39;s server.log, but the README only describes foreground `lavish-axi server --verbose` logging to stderr. Add the new detached log location and when users should inspect it for startup or crash diagnostics.
- ⚠️ `AGENTS.md:44` - The architecture doc still says session URLs are returned as `http://localhost:PORT/session/&lt;key&gt;`, but the server and CLI now consistently bind and emit `http://127.0.0.1:PORT/...`. Update the documented request flow to match the new loopback host behavior.
- ℹ️ `AGENTS.md:49` - The request-flow docs do not describe the new chrome queue durability contract: prompts are loaded from sessionStorage, persisted on queue/remove, and removed only after a successful `/api/:key/prompts` response. Add this so future changes preserve the intended reload and failed-send behavior.
- ℹ️ `AGENTS.md:50` - The poll flow now streams whitespace heartbeat bytes for default no-timeout long polls before the final JSON response, but AGENTS.md still describes the poll as simply waiting on an EventEmitter until feedback or end. Document the heartbeat behavior and that `--timeout-ms` keeps the non-streaming test/debug path.
- ℹ️ `AGENTS.md:62` - The operational docs mention `server --verbose` stderr logging, but the change also appends detached server output to `server.log` in `LAVISH_AXI_STATE_DIR`. Add this location to the diagnostics guidance so opaque detached startup/crash failures are discoverable.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `src/cli.js:508` - The new detached-server logging behavior is documented in README.md and AGENTS.md, but the built-in `lavish-axi server` command help still only tells users about `--verbose` stderr logging. Update the server help text to mention that detached stdout/stderr is appended to `~/.lavish-axi/server.log` or `LAVISH_AXI_STATE_DIR/server.log` so users relying on CLI help can find startup and crash diagnostics.

**Round 3** (auto-fix) - found 1 warning
- ⚠️ `src/cli.js:472` - The new poll/server connection failure suggestions still only tell users to run `lavish-axi server --verbose`, but this change adds detached stdout/stderr capture specifically for opaque startup and crash diagnostics. Update the `serverConnectionError()` and `pollResponseInterruptedError()` suggestions to mention `~/.lavish-axi/server.log` or `LAVISH_AXI_STATE_DIR/server.log`, matching the README and server help.

**Round 4** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
