### PR TITLE
fix(cli): require explicit agent hook setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ Detached server stdout/stderr is also appended to `server.log` in `LAVISH_AXI_ST
 
 ### AXI integration
 
-The CLI is built on `axi-sdk-js` (`runAxiCli`). The `home()` callback returns the rich object shown when the user runs `lavish-axi` with no arguments - this is the same TOON-serialized output that lands in the agent's `SessionStart` hook (`sessions`, `visual_guidance`, `playbooks`, `help`). Top-level `--help` returns the same static guidance without dynamic sessions, `lavish-axi playbook [playbook_id]` exposes focused artifact guidance, and `lavish-axi design` prints copy-pasteable Tailwind/DaisyUI CDN URLs plus the DaisyUI component reference (opt-in - artifacts stay portable by default). The bare-arg form (`lavish-axi some.html`) is normalized into `["open", "some.html"]` by `normalizeArgv`.
+The CLI is built on `axi-sdk-js` (`runAxiCli`). The `home()` callback returns the rich object shown when the user runs `lavish-axi` with no arguments - this is the same TOON-serialized output that lands in the agent's optional `SessionStart` hook after `lavish-axi setup hooks` (`sessions`, `visual_guidance`, `playbooks`, `help`). Top-level `--help` returns the same static guidance without dynamic sessions, `lavish-axi playbook [playbook_id]` exposes focused artifact guidance, and `lavish-axi design` prints copy-pasteable Tailwind/DaisyUI CDN URLs plus the DaisyUI component reference (opt-in - artifacts stay portable by default). The bare-arg form (`lavish-axi some.html`) is normalized into `["open", "some.html"]` by `normalizeArgv`.
 
 ### Telemetry
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ pnpm link
 | `lavish-axi end <html-file>`  | End a session.                                               |
 | `lavish-axi playbook [id]`    | List focused artifact guidance or show one playbook.         |
 | `lavish-axi design`           | Show CDN snippet + DaisyUI component reference (opt-in).     |
-| `lavish-axi setup hooks`      | Install optional agent session hooks.                        |
+| `lavish-axi setup hooks`      | Install or repair optional SessionStart hooks for Claude Code, Codex, and OpenCode; restart the agent session afterward. |
 | `lavish-axi server`           | Run the local Lavish Editor server.                          |
 
 Known playbook IDs: `diagram`, `table`, `comparison`, `plan`, `diff`, `input`, `slides`.

--- a/README.md
+++ b/README.md
@@ -105,16 +105,16 @@ pnpm link
 
 ## CLI Reference
 
-| Command                       | Description                                                  |
-| ----------------------------- | ------------------------------------------------------------ |
-| `lavish-axi`                  | Show current sessions and usage guidance.                    |
-| `lavish-axi <html-file>`      | Open or resume a Lavish Editor session.                      |
-| `lavish-axi poll <html-file>` | Long-poll until the user sends feedback or ends the session. |
-| `lavish-axi end <html-file>`  | End a session.                                               |
-| `lavish-axi playbook [id]`    | List focused artifact guidance or show one playbook.         |
-| `lavish-axi design`           | Show CDN snippet + DaisyUI component reference (opt-in).     |
+| Command                       | Description                                                                                                              |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `lavish-axi`                  | Show current sessions and usage guidance.                                                                                |
+| `lavish-axi <html-file>`      | Open or resume a Lavish Editor session.                                                                                  |
+| `lavish-axi poll <html-file>` | Long-poll until the user sends feedback or ends the session.                                                             |
+| `lavish-axi end <html-file>`  | End a session.                                                                                                           |
+| `lavish-axi playbook [id]`    | List focused artifact guidance or show one playbook.                                                                     |
+| `lavish-axi design`           | Show CDN snippet + DaisyUI component reference (opt-in).                                                                 |
 | `lavish-axi setup hooks`      | Install or repair optional SessionStart hooks for Claude Code, Codex, and OpenCode; restart the agent session afterward. |
-| `lavish-axi server`           | Run the local Lavish Editor server.                          |
+| `lavish-axi server`           | Run the local Lavish Editor server.                                                                                      |
 
 Known playbook IDs: `diagram`, `table`, `comparison`, `plan`, `diff`, `input`, `slides`.
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ pnpm link
 | `lavish-axi end <html-file>`  | End a session.                                               |
 | `lavish-axi playbook [id]`    | List focused artifact guidance or show one playbook.         |
 | `lavish-axi design`           | Show CDN snippet + DaisyUI component reference (opt-in).     |
+| `lavish-axi setup hooks`      | Install optional agent session hooks.                        |
 | `lavish-axi server`           | Run the local Lavish Editor server.                          |
 
 Known playbook IDs: `diagram`, `table`, `comparison`, `plan`, `diff`, `input`, `slides`.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@tailwindcss/browser": "4.2.4",
-    "axi-sdk-js": "^0.1.6",
+    "axi-sdk-js": "^0.1.7",
     "chokidar": "^4.0.3",
     "daisyui": "^5.5.19",
     "express": "^5.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,8 +11,8 @@ importers:
         specifier: 4.2.4
         version: 4.2.4
       axi-sdk-js:
-        specifier: ^0.1.6
-        version: 0.1.6
+        specifier: ^0.1.7
+        version: 0.1.7
       chokidar:
         specifier: ^4.0.3
         version: 4.0.3
@@ -351,9 +351,9 @@ packages:
     resolution:
       { integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw== }
 
-  axi-sdk-js@0.1.6:
+  axi-sdk-js@0.1.7:
     resolution:
-      { integrity: sha512-Nc/mNasFUVqBieSOLGt2A5u4pJEOZPpueq+ignqoY+vcg8j4VuAvhWTn3cJ7hhTkGVqLg4yjTdjMi4tXyOCsCA== }
+      { integrity: sha512-kzIeuQHZx3FFpzJknq+sdbi3XBGdyPGMdOHM2Zepa4MF5MpckhPeWPd5x+RX6gBKEWZdaW73YrOPY+HAGyLekw== }
     engines: { node: ">=20" }
 
   balanced-match@4.0.4:
@@ -1171,7 +1171,7 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  axi-sdk-js@0.1.6:
+  axi-sdk-js@0.1.7:
     dependencies:
       "@toon-format/toon": 2.1.0
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -529,7 +529,7 @@ const COMMAND_HELP = {
   end: `Usage: lavish-axi end <html-file>\n\nEnd a Lavish Editor session.\n`,
   playbook: `Usage: lavish-axi playbook [playbook_id]\n\nList focused artifact guidance playbooks, or show one playbook by ID. Known IDs: diagram, table, comparison, plan, diff, input, slides.\n\nExamples:\n  lavish-axi playbook\n  lavish-axi playbook diagram\n  lavish-axi playbook input\n`,
   design: `Usage: lavish-axi design\n\nShow a copy-pasteable CDN snippet for Tailwind CSS browser runtime v4 + DaisyUI v5 + themes, plus technical reference for DaisyUI components. Lavish artifacts stay portable HTML. Prefer the CDN snippet over hand-writing styles unless explicitly instructed otherwise by the user. If the user asks for another design system or plain HTML, follow that request.\n`,
-  setup: `Usage: lavish-axi setup hooks\n\nInstall or repair agent SessionStart hooks for lavish-axi ambient context.\n`,
+  setup: `Usage: lavish-axi setup hooks\n\nInstall or repair agent SessionStart hooks for lavish-axi ambient context in Claude Code, Codex, and OpenCode. Restart your agent session afterward to receive the context.\n`,
   server: `Usage: lavish-axi server [--port 4387] [--verbose]\n\nRun the local Lavish Editor server. Pass --verbose (or set LAVISH_AXI_DEBUG=1) to log session and watcher events to stderr. Detached server output is appended to ~/.lavish-axi/server.log, or LAVISH_AXI_STATE_DIR/server.log when set, for startup and crash diagnostics.\n`,
 };
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -252,6 +252,7 @@ async function setupCommand(args) {
     marker: "lavish-axi",
     binaryNames: ["lavish-axi"],
     distEntrypoints: ["dist/cli.mjs", "bin/lavish-axi.js"],
+    homeDir: resolveHookHomeDir(),
     onError: (message) => errors.push(message),
   });
 
@@ -263,6 +264,10 @@ async function setupCommand(args) {
     hooks: { status: "installed", integrations: "Claude Code, Codex, OpenCode" },
     help: ["Restart your agent session to receive lavish-axi ambient context"],
   };
+}
+
+export function resolveHookHomeDir(env = process.env, fallback = os.homedir()) {
+  return env.HOME || fallback;
 }
 
 async function serverCommand(args) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -247,11 +247,17 @@ async function setupCommand(args) {
     throw new AxiError("Unknown setup action", "VALIDATION_ERROR", ["Run `lavish-axi setup hooks`"]);
   }
 
+  const errors = [];
   installSessionStartHooks({
     marker: "lavish-axi",
     binaryNames: ["lavish-axi"],
     distEntrypoints: ["dist/cli.mjs", "bin/lavish-axi.js"],
+    onError: (message) => errors.push(message),
   });
+
+  if (errors.length > 0) {
+    throw new AxiError("Failed to install lavish-axi agent hooks", "SERVER_ERROR", errors);
+  }
 
   return {
     hooks: { status: "installed", integrations: "Claude Code, Codex, OpenCode" },

--- a/src/cli.js
+++ b/src/cli.js
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { AxiError, runAxiCli } from "axi-sdk-js";
+import { AxiError, installSessionStartHooks, runAxiCli } from "axi-sdk-js";
 
 import { createDesignOutput, DESIGN_SYSTEM_HINT } from "./design-reference.js";
 import { defaultPort, ensureStateDir, LOOPBACK_HOST, serverLogFile, stateFile } from "./paths.js";
@@ -14,7 +14,7 @@ import { serve } from "./server.js";
 import { canonicalFile, sessionKey, SessionStore } from "./session-store.js";
 import { initDefaultTelemetry } from "./telemetry.js";
 
-const COMMANDS = new Set(["open", "poll", "end", "server", "playbook", "design"]);
+const COMMANDS = new Set(["open", "poll", "end", "server", "playbook", "design", "setup"]);
 const DESCRIPTION =
   "Lavish Editor helps agents turn rich HTML artifacts into collaborative human review surfaces. Whenever you are about to give user a complex response that will be easier to understand via a rich / interactive page, consider using Lavish Editor. " +
   "First generate an interactive HTML artifact according to user request, then run `lavish-axi <html-file>` so the user can visually review it, annotate elements or selected text, queue prompts, and send feedback back through `lavish-axi poll`.";
@@ -41,7 +41,6 @@ export async function run(argv) {
       version: VERSION,
       argv: isTopLevelHelp ? [] : normalizedArgv,
       topLevelHelp: TOP_LEVEL_HELP,
-      hooks: { binaryNames: ["lavish-axi"] },
       home: async () =>
         createHomeOutput({
           bin: process.argv[1] || "lavish-axi",
@@ -54,6 +53,7 @@ export async function run(argv) {
         end: endCommand,
         playbook: playbookCommand,
         design: designCommand,
+        setup: setupCommand,
         server: serverCommand,
       },
       getCommandHelp,
@@ -240,6 +240,23 @@ async function playbookCommand(args) {
 
 async function designCommand() {
   return createDesignOutput();
+}
+
+async function setupCommand(args) {
+  if (args.length !== 1 || args[0] !== "hooks") {
+    throw new AxiError("Unknown setup action", "VALIDATION_ERROR", ["Run `lavish-axi setup hooks`"]);
+  }
+
+  installSessionStartHooks({
+    marker: "lavish-axi",
+    binaryNames: ["lavish-axi"],
+    distEntrypoints: ["dist/cli.mjs", "bin/lavish-axi.js"],
+  });
+
+  return {
+    hooks: { status: "installed", integrations: "Claude Code, Codex, OpenCode" },
+    help: ["Restart your agent session to receive lavish-axi ambient context"],
+  };
 }
 
 async function serverCommand(args) {
@@ -498,7 +515,7 @@ export function getCommandHelp(command) {
   return COMMAND_HELP[command] || null;
 }
 
-const TOP_LEVEL_HELP = `lavish-axi - Lavish Editor AXI\n\nUsage:\n  lavish-axi\n  lavish-axi <html-file>\n  lavish-axi poll <html-file> [--agent-reply "..."]\n  lavish-axi end <html-file>\n  lavish-axi playbook [playbook_id]\n  lavish-axi design\n\n${DESIGN_SYSTEM_HINT}\n\nNote: poll long-polls indefinitely by default until the user sends feedback or ends the session. Do not pass --timeout-ms during normal agent use; it is for tests and debugging only. do not set a short shell timeout; either run it without a timeout or use a very high threshold above 10 minutes.\n\n`;
+const TOP_LEVEL_HELP = `lavish-axi - Lavish Editor AXI\n\nUsage:\n  lavish-axi\n  lavish-axi <html-file>\n  lavish-axi poll <html-file> [--agent-reply "..."]\n  lavish-axi end <html-file>\n  lavish-axi playbook [playbook_id]\n  lavish-axi design\n  lavish-axi setup hooks\n\n${DESIGN_SYSTEM_HINT}\n\nNote: poll long-polls indefinitely by default until the user sends feedback or ends the session. Do not pass --timeout-ms during normal agent use; it is for tests and debugging only. do not set a short shell timeout; either run it without a timeout or use a very high threshold above 10 minutes.\n\n`;
 
 const COMMAND_HELP = {
   open: `Usage: lavish-axi <html-file> [--no-open]\n\nOpen or resume a Lavish Editor review session for an HTML artifact. Use --no-open when you need to ensure the server/session exists without opening another browser window.\n`,
@@ -506,6 +523,7 @@ const COMMAND_HELP = {
   end: `Usage: lavish-axi end <html-file>\n\nEnd a Lavish Editor session.\n`,
   playbook: `Usage: lavish-axi playbook [playbook_id]\n\nList focused artifact guidance playbooks, or show one playbook by ID. Known IDs: diagram, table, comparison, plan, diff, input, slides.\n\nExamples:\n  lavish-axi playbook\n  lavish-axi playbook diagram\n  lavish-axi playbook input\n`,
   design: `Usage: lavish-axi design\n\nShow a copy-pasteable CDN snippet for Tailwind CSS browser runtime v4 + DaisyUI v5 + themes, plus technical reference for DaisyUI components. Lavish artifacts stay portable HTML. Prefer the CDN snippet over hand-writing styles unless explicitly instructed otherwise by the user. If the user asks for another design system or plain HTML, follow that request.\n`,
+  setup: `Usage: lavish-axi setup hooks\n\nInstall or repair agent SessionStart hooks for lavish-axi ambient context.\n`,
   server: `Usage: lavish-axi server [--port 4387] [--verbose]\n\nRun the local Lavish Editor server. Pass --verbose (or set LAVISH_AXI_DEBUG=1) to log session and watcher events to stderr. Detached server output is appended to ~/.lavish-axi/server.log, or LAVISH_AXI_STATE_DIR/server.log when set, for startup and crash diagnostics.\n`,
 };
 

--- a/test/cli-output.test.js
+++ b/test/cli-output.test.js
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import os from "node:os";
 import { fileURLToPath } from "node:url";
@@ -276,6 +276,33 @@ test("setup hooks installs agent session hooks explicitly", async () => {
     assert.match(result.stdout, /status: installed/);
     assert.match(result.stdout, /Restart your agent session/);
     assert.ok(existsSync(`${homeDir}/.claude/settings.json`));
+  } finally {
+    await rm(stateDir, { force: true, recursive: true });
+    await rm(homeDir, { force: true, recursive: true });
+  }
+});
+
+test("setup hooks exits with an error when hook installation fails", async () => {
+  const stateDir = await mkdtemp(`${os.tmpdir()}/lavish-axi-setup-fail-state-`);
+  const homeDir = await mkdtemp(`${os.tmpdir()}/lavish-axi-setup-fail-home-`);
+  try {
+    await mkdir(`${homeDir}/.claude`, { recursive: true });
+    await writeFile(`${homeDir}/.claude/settings.json`, "{ invalid json", "utf8");
+
+    const result = spawnSync(
+      process.execPath,
+      [fileURLToPath(new URL("../bin/lavish-axi.js", import.meta.url)), "setup", "hooks"],
+      {
+        cwd: fileURLToPath(new URL("..", import.meta.url)),
+        encoding: "utf8",
+        env: { ...process.env, HOME: homeDir, LAVISH_AXI_STATE_DIR: stateDir },
+      },
+    );
+
+    const output = `${result.stdout}\n${result.stderr}`;
+    assert.notEqual(result.status, 0, result.stdout);
+    assert.match(output, /hook/i);
+    assert.doesNotMatch(result.stdout, /status: installed/);
   } finally {
     await rm(stateDir, { force: true, recursive: true });
     await rm(homeDir, { force: true, recursive: true });

--- a/test/cli-output.test.js
+++ b/test/cli-output.test.js
@@ -251,9 +251,35 @@ test("html file arguments normalize to the hidden open command", () => {
   assert.deepEqual(normalizeArgv(["report.html"]), ["open", "report.html"]);
   assert.deepEqual(normalizeArgv(["--no-open", "report.html"]), ["open", "--no-open", "report.html"]);
   assert.deepEqual(normalizeArgv(["poll", "report.html"]), ["poll", "report.html"]);
+  assert.deepEqual(normalizeArgv(["setup", "hooks"]), ["setup", "hooks"]);
   assert.deepEqual(normalizeArgv(["playbook", "diagram"]), ["playbook", "diagram"]);
   assert.deepEqual(normalizeArgv(["design"]), ["design"]);
   assert.deepEqual(normalizeArgv(["--help"]), ["--help"]);
+});
+
+test("setup hooks installs agent session hooks explicitly", async () => {
+  const stateDir = await mkdtemp(`${os.tmpdir()}/lavish-axi-setup-state-`);
+  const homeDir = await mkdtemp(`${os.tmpdir()}/lavish-axi-setup-home-`);
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [fileURLToPath(new URL("../bin/lavish-axi.js", import.meta.url)), "setup", "hooks"],
+      {
+        cwd: fileURLToPath(new URL("..", import.meta.url)),
+        encoding: "utf8",
+        env: { ...process.env, HOME: homeDir, LAVISH_AXI_STATE_DIR: stateDir },
+      },
+    );
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /hooks:/);
+    assert.match(result.stdout, /status: installed/);
+    assert.match(result.stdout, /Restart your agent session/);
+    assert.ok(existsSync(`${homeDir}/.claude/settings.json`));
+  } finally {
+    await rm(stateDir, { force: true, recursive: true });
+    await rm(homeDir, { force: true, recursive: true });
+  }
 });
 
 test("telemetry command names are anonymous and do not include file paths", () => {

--- a/test/cli-output.test.js
+++ b/test/cli-output.test.js
@@ -20,6 +20,7 @@ import {
   fetchJson,
   getCommandHelp,
   normalizeArgv,
+  resolveHookHomeDir,
   resolveServerEntry,
   shouldForceRestartForLocalBuild,
   shouldKillProcessOnPort,
@@ -255,6 +256,13 @@ test("html file arguments normalize to the hidden open command", () => {
   assert.deepEqual(normalizeArgv(["playbook", "diagram"]), ["playbook", "diagram"]);
   assert.deepEqual(normalizeArgv(["design"]), ["design"]);
   assert.deepEqual(normalizeArgv(["--help"]), ["--help"]);
+});
+
+test("setup hooks resolves HOME before platform-specific user profile variables", () => {
+  assert.equal(
+    resolveHookHomeDir({ HOME: "/tmp/lavish-home", USERPROFILE: "C:\\Users\\runneradmin" }, "/fallback"),
+    "/tmp/lavish-home",
+  );
 });
 
 test("setup hooks installs agent session hooks explicitly", async () => {

--- a/test/package-json.test.js
+++ b/test/package-json.test.js
@@ -39,7 +39,7 @@ test("pnpm lock root importer matches the publish manifest", async () => {
     const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     const escapedSpecifier = specifier.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
-    assert.match(pnpmLock, new RegExp(`"?${escapedName}"?:[\\s\\S]*?specifier: ${escapedSpecifier}`));
+    assert.match(pnpmLock, new RegExp(`["']?${escapedName}["']?:[\\s\\S]*?specifier: ${escapedSpecifier}`));
   }
 });
 


### PR DESCRIPTION
## Intent

The developer wanted to fix a portability regression in lavish-axi caused by automatic injection of server-relative Tailwind/DaisyUI design assets into generated HTML artifacts. They required removing the auto-injection and obsolete opt-out logic while keeping existing /design/* routes for backwards compatibility. They also wanted agent-facing guidance, README, AGENTS.md, and lavish-axi design output updated to make artifacts portable by default and provide pinned CDN snippets for optional Tailwind v4 and DaisyUI v5 usage, while noting agents may use any design system or none. They explicitly required TDD with updated regression tests, pnpm run check passing, and no PR creation because ezoss would handle it.

## What Changed

- Removed automatic SessionStart hook installation from normal CLI startup and added an explicit `lavish-axi setup hooks` command for Claude Code, Codex, and OpenCode.
- Made hook setup report installation failures instead of returning `status: installed` when target config writes or parsing fail.
- Updated README, CLI help, dependency metadata, and regression coverage for the explicit setup flow and restart guidance.

## Risk Assessment

✅ Low: The change is narrowly scoped to making agent hook installation explicit, includes error reporting for failed writes, and leaves existing open/poll/server paths largely untouched.

## Testing

<code>Focused regression tests passed, the real CLI design output showed pinned CDN guidance with no auto-injection requirement, a served artifact preserved its original head while only adding the Lavish SDK and no `/design/*` assets, the legacy `/design/daisyui.css` route still returned 200, explicit hook setup created agent settings, and no verification files were left behind.</code>

<details>
<summary>Evidence: `lavish-axi design` user-facing CDN guidance</summary>

```text
design:
summary: Lavish does not auto-inject any design system. Artifacts stay portable HTML. Paste the CDN snippet below into your `<head>` to use Tailwind CSS browser runtime v4 + DaisyUI v5 + themes. Prefer this CDN snippet over hand-writing styles unless explicitly instructed otherwise by the user.
cdn_snippet: "<link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/daisyui@5.5.19/daisyui.css\">\n<link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/daisyui@5.5.19/themes.css\">\n<script src=\"https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4.2.4/dist/index.global.js\"></script>"
cdn_urls:
tailwind: "https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4.2.4/dist/index.global.js"
daisyui: "https://cdn.jsdelivr.net/npm/daisyui@5.5.19/daisyui.css"
daisyuiThemes: "https://cdn.jsdelivr.net/npm/daisyui@5.5.19/themes.css"
other_design_systems: "If the user asks for a different design system (Bootstrap, custom CSS, plain HTML, etc.), use that instead - Lavish does not require DaisyUI."
```
</details>
<details>
<summary>Evidence: Served artifact portability evidence</summary>

```text
{
"open_status": 0,
"session_output": "session:\n url: \"http://127.0.0.1:49705/session/fdf136ca398596c7\"\n status: opened",
"artifact_status": 200,
"sdk_injected": true,
"injected_design_assets": [],
"head_fragment": "<head><title>Portable</title></head>",
"body_suffix": "\">Portable artifact</h1><script src=\"/sdk.js?key=fdf136ca398596c7\"></script></body></html>",
"backwards_compat_design_route_status": 200
}
```
</details>
<details>
<summary>Evidence: Explicit hook setup evidence</summary>

```text
{
"exit_status": 0,
"output": "hooks:\n status: installed\n integrations: \"Claude Code, Codex, OpenCode\"\nhelp[1]: Restart your agent session to receive lavish-axi ambient context",
"claude_settings_created": true,
"settings_mentions_lavish_axi": true
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 warning
- ⚠️ `src/cli.js:250` - `setup hooks` does not pass an `onError` callback to `installSessionStartHooks`, whose implementation swallows per-target write/parse failures by default. If a target config is invalid JSON or unwritable, the command can still exit successfully and report `status: installed`, leaving users believing hooks were installed when they were not.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `node --test test/html-transform.test.js test/server.test.js test/cli-output.test.js test/package-json.test.js`
- `node bin/lavish-axi.js design`
- <code>Manual CLI/server check: created a temporary HTML artifact, ran `node bin/lavish-axi.js .lavish-test/manual-portability/portable.html --no-open` with isolated `LAVISH_AXI_PORT` and `LAVISH_AXI_STATE_DIR`, fetched `/artifact/&lt;key&gt;/index.html`, fetched `/design/daisyui.css`, then shut down the server</code>
- <code>Manual CLI hook check: ran `node bin/lavish-axi.js setup hooks` with isolated `HOME` and `LAVISH_AXI_STATE_DIR`, then inspected the generated Claude settings file</code>
- `git status --short`

</details>

<details>
<summary>🔧 **Document** - 2 issues found → auto-fixed</summary>

**Round 1** - found 2 warnings
- ⚠️ `README.md:116` - The new public `lavish-axi setup hooks` command is documented only as &#34;Install optional agent session hooks.&#34; The implementation mutates agent configuration by installing or repairing SessionStart hooks for Claude Code, Codex, and OpenCode, and users must restart the agent session afterward. The README should document those side effects and supported integrations so users understand what explicit consent covers before running the command.
- ⚠️ `src/cli.js:532` - The command-specific help for `lavish-axi setup hooks` says it installs or repairs SessionStart hooks, but it omits the supported integrations and the required restart step that the command result reports after installation. Update this CLI help text so `lavish-axi setup --help` or equivalent command help is complete before users execute the config-mutating setup command.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
