### PR TITLE
feat(cli): broaden plan playbook guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Lavish Editor opens agent-generated HTML files in a local browser, lets you pinp
 
 - **Local only** - Work with your local HTML artifacts with a local CLI. Zero cloud dependency.
 - **Human-AI collaboration** - Annotate elements, selected text ranges, and send messages to the agent without leaving Lavish Editor.
-- **Battery included** - Lavish Editor teaches your agent good visualization for common use cases such as technial plans, design explorations and more out of the box.
+- **Battery included** - Lavish Editor teaches your agent good visualization for common use cases such as product or technical plans, design explorations and more out of the box.
 
 Lavish Editor is an [AXI](https://axi.md), which means -
 
@@ -48,7 +48,7 @@ Lavish Editor is an [AXI](https://axi.md), which means -
 Just tell your agent:
 
 ```sh
-Use `npx lavish-axi` to write a technical plan for what we discussed.
+Use `npx lavish-axi` to write a product or technical plan for what we discussed.
 ```
 
 ## Install

--- a/src/cli.js
+++ b/src/cli.js
@@ -125,7 +125,7 @@ export function createHomeOutput({ bin, sessions, includeSessions = true }) {
       "Run `lavish-axi end <html-file>` to end a session",
       "Run `lavish-axi playbook <playbook_id>` for focused artifact guidance",
       DESIGN_SYSTEM_HINT,
-      "Use lavish-axi when the user asks for a visual artifact, HTML explainer, interactive prototype, review surface, technical plan, comparison, report, or browser-based feedback loop",
+      "Use lavish-axi when the user asks for a visual artifact, HTML explainer, interactive prototype, review surface, product or technical plan, comparison, report, or browser-based feedback loop",
     ],
   };
 }

--- a/src/playbooks.js
+++ b/src/playbooks.js
@@ -85,31 +85,28 @@ export const PLAYBOOKS = [
   },
   {
     id: "plan",
-    use_when: "Explain a technical plan before implementation",
+    use_when: "Explain a product or technical plan before implementation",
     choose: [
       "Use this when the user needs to inspect a feature approach before implementation begins.",
-      "Use it when state, APIs, files, tests, or edge cases are numerous enough to deserve a visual map.",
-      "Use a lighter comparison or diagram playbook when the plan is only a small design choice.",
+      "Use it when the user explicitly asked for a PRD, technical design, implementation plan or proposal.",
+      "Use a lighter comparison or diagram playbook when the plan is only a single small design choice.",
     ],
     structure: [
-      "Start with the problem, the desired behavior, and what is out of scope.",
-      "Show affected state, commands, functions, files, and user-visible behavior.",
-      "Include edge cases and tests before implementation notes so risk is visible early.",
+      "Start with the goal, the current state, and desired behavior.",
+      "Then describe the a proposed approach, focusing on high level decisions.",
+      "At the end, list any risks you see, and open questions you have, and follow the 'comparison' playbook to provide options for the user to choose from.",
     ],
     design_rules: [
       "Verify each claim against the codebase before presenting it as fact.",
-      "Keep code snippets focused on the pattern or seam, not full-file dumps.",
-      "Make test requirements concrete enough to drive TDD.",
+      "When discussing frontend experiences, prefer visually mocking the experience under a consistent design system as the real product over describing it with text.",
+      "The plan needs to be self-contained enough that another developer can read it and fully implement the proposal.",
     ],
     pitfalls: [
-      "Do not invent extension points or APIs that are not present in the repo.",
-      "Do not turn a plan into a long prose essay when state and file maps would be clearer.",
+      "Do not leave resolved open questions in the artifact. Update existing content to reflect the decision and remove the open question.",
+      "Do not only focus on ambiguous decisions and omit the actual proposal.",
       "Do not omit failure modes, migration concerns, or backwards compatibility questions.",
     ],
-    lavish_notes: [
-      "A Lavish plan should make uncertainties easy to annotate before code exists.",
-      "Use controls for scope choices so the user can queue a precise implementation direction.",
-    ],
+    lavish_notes: ["A Lavish plan should make a plan and its uncertainties easy to annotate before code exists."],
   },
   {
     id: "diff",

--- a/src/playbooks.js
+++ b/src/playbooks.js
@@ -93,7 +93,7 @@ export const PLAYBOOKS = [
     ],
     structure: [
       "Start with the goal, the current state, and desired behavior.",
-      "Then describe the a proposed approach, focusing on high level decisions.",
+      "Then describe a proposed approach, focusing on high level decisions.",
       "At the end, list any risks you see, and open questions you have, and follow the 'comparison' playbook to provide options for the user to choose from.",
     ],
     design_rules: [

--- a/test/cli-output.test.js
+++ b/test/cli-output.test.js
@@ -190,16 +190,8 @@ test("playbook detail output returns focused Lavish-native guidance", () => {
 test("plan playbook detail output has polished guidance copy", () => {
   const output = createPlaybookOutput(["plan"]);
 
-  assert.ok(
-    output.playbook.structure.some((item) =>
-      item.includes("Then describe a proposed approach"),
-    ),
-  );
-  assert.ok(
-    output.playbook.structure.every(
-      (item) => !item.includes("Then describe the a proposed approach"),
-    ),
-  );
+  assert.ok(output.playbook.structure.some((item) => item.includes("Then describe a proposed approach")));
+  assert.ok(output.playbook.structure.every((item) => !item.includes("Then describe the a proposed approach")));
 });
 
 test("unknown playbook ids produce an actionable validation error", () => {

--- a/test/cli-output.test.js
+++ b/test/cli-output.test.js
@@ -162,7 +162,7 @@ test("playbook index output lists known playbooks with concise descriptions", ()
   );
   assert.equal(
     output.playbooks.find((playbook) => playbook.id === "plan")?.use_when,
-    "Explain a technical plan before implementation",
+    "Explain a product or technical plan before implementation",
   );
   assert.equal(
     output.playbooks.find((playbook) => playbook.id === "input")?.use_when,

--- a/test/cli-output.test.js
+++ b/test/cli-output.test.js
@@ -187,6 +187,21 @@ test("playbook detail output returns focused Lavish-native guidance", () => {
   assert.ok(output.playbook.lavish_notes.some((item) => item.includes("Lavish")));
 });
 
+test("plan playbook detail output has polished guidance copy", () => {
+  const output = createPlaybookOutput(["plan"]);
+
+  assert.ok(
+    output.playbook.structure.some((item) =>
+      item.includes("Then describe a proposed approach"),
+    ),
+  );
+  assert.ok(
+    output.playbook.structure.every(
+      (item) => !item.includes("Then describe the a proposed approach"),
+    ),
+  );
+});
+
 test("unknown playbook ids produce an actionable validation error", () => {
   assert.throws(
     () => createPlaybookOutput(["unknown"]),


### PR DESCRIPTION
## Intent

The developer wanted to locate where the technical plan playbook is defined in the codebase. They were specifically asking about the source of the “plan” playbook guidance that appears in Lavish AXI playbooks, including how it is surfaced through the CLI or session-start output.

## What Changed

- Expanded the `plan` playbook copy to cover product plans, PRDs, technical designs, implementation plans, and proposals instead of only technical plans.
- Updated CLI home/help guidance and README examples so the broader planning use case is visible in user-facing surfaces.
- Adjusted playbook CLI output expectations to match the revised copy and corrected the user-facing grammar typo found during validation.

## Risk Assessment

✅ Low: The change is limited to static playbook guidance text plus the matching output expectation, with no execution-path or data-shape changes.

## Testing

<code>Ran focused help and playbook CLI tests, then captured the actual `lavish-axi playbook plan` and top-level help outputs; both end-user surfaces show the updated product-or-technical plan guidance with the corrected proposed-approach copy.</code>

<details>
<summary>Evidence: Plan playbook CLI output</summary>

Source: local file <code>/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/no-mistakes-evidence/01KSC78S73F74P1ZZBZM5VEJFG/playbook-plan-output.txt</code>

```text
playbook:
id: plan
use_when: Explain a product or technical plan before implementation
structure[3]: "Start with the goal, the current state, and desired behavior.","Then describe a proposed approach, focusing on high level decisions.","At the end, list any risks you see, and open questions you have, and follow the 'comparison' playbook to provide options for the user to choose from."
```
</details>
<details>
<summary>Evidence: Top-level help playbook index output</summary>

Source: local file <code>/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/no-mistakes-evidence/01KSC78S73F74P1ZZBZM5VEJFG/help-output.txt</code>

```text
playbooks[7]{id,use_when}:
diagram,"Map relationships, flows, state, and architecture"
table,Turn dense records into scan-friendly review surfaces
comparison,"Show options, tradeoffs, and current vs target behavior"
plan,Explain a product or technical plan before implementation
diff,Present code or PR changes with evidence and findings
input,"Must be used when the agent needs to collect user input on decisions, choices, preferences, triage, scope, or other structured feedback from within the artifact"
slides,Create a deliberate presentation when slides are requested
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed across 2 runs (3m28s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 error
- 🚨 `src/playbooks.js:88` - Changing the plan playbook summary here leaves the exact assertion in `test/cli-output.test.js` expecting `Explain a technical plan before implementation`, so the existing CLI output test will fail until that expectation is updated to the new product/technical wording.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 warning
- ⚠️ `src/playbooks.js:96` - The end-user `lavish-axi playbook plan` output includes the sentence `Then describe the a proposed approach, focusing on high level decisions.`, which is a grammar typo in the newly updated plan guidance. The focused tests pass, but the captured CLI evidence shows this typo on the actual user-facing surface.
- `node --test --test-name-pattern "playbook" test/cli-output.test.js`
- `node --test --test-name-pattern "home output|top-level help|playbook" test/cli-output.test.js`
- `node bin/lavish-axi.js playbook plan > /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/no-mistakes-evidence/01KSC78S73F74P1ZZBZM5VEJFG/playbook-plan-output.txt`
- `node bin/lavish-axi.js --help > /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/no-mistakes-evidence/01KSC78S73F74P1ZZBZM5VEJFG/help-output.txt`

**Round 2** (auto-fix) - passed ✅
- `node --test --test-name-pattern "playbook" test/cli-output.test.js`
- `node --test --test-name-pattern "home output|top-level help|playbook" test/cli-output.test.js`
- `node bin/lavish-axi.js playbook plan > /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/no-mistakes-evidence/01KSC78S73F74P1ZZBZM5VEJFG/playbook-plan-output.txt`
- `LAVISH_AXI_STATE_DIR="/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/no-mistakes-evidence/01KSC78S73F74P1ZZBZM5VEJFG/state" node bin/lavish-axi.js --help > /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/no-mistakes-evidence/01KSC78S73F74P1ZZBZM5VEJFG/help-output.txt`

</details>

<details>
<summary>🔧 **Document** - 2 issues found → auto-fixed</summary>

**Round 1** - found 2 warnings
- ⚠️ `src/cli.js:128` - The public `lavish-axi` home/help guidance still lists `technical plan` as the planning use case, but the plan playbook now explicitly covers product plans, PRDs, technical designs, implementation plans, and proposals. Update this user-facing guidance so agents discover the expanded plan scope without needing to inspect `lavish-axi playbook plan`.
- ⚠️ `README.md:51` - The README quick-start example still tells users to ask for a `technical plan` only, while the changed plan playbook is now intended for product or technical plans including PRDs, designs, implementation plans, and proposals. Update the README example and nearby feature copy to document the expanded planning behavior.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
