### PR TITLE
fix(cli): make interrupted poll guidance reliable

### DIFF
--- a/.no-mistakes/evidence/fix/poll-signal-registration-race/poll-sigterm-tight-loop-transcript.txt
+++ b/.no-mistakes/evidence/fix/poll-signal-registration-race/poll-sigterm-tight-loop-transcript.txt
@@ -1,0 +1,38 @@
+lavish-axi poll SIGTERM tight-loop evidence
+attempts: 100
+misses: 0
+artifact: /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/lavish-axi-poll-signal-e2e-dvrSP2/artifact.html
+
+Method: for each attempt, spawn the real CLI poll command, wait until stderr contains the long-poll banner, immediately send SIGTERM, wait for child close, then assert stderr includes the interrupted-poll re-run guidance.
+
+Sample attempts:
+--- attempt 1 ---
+closed: {"code":143,"signal":null}
+hasGuidance: true
+stderr:
+[lavish-axi] Long-polling for user feedback on /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/lavish-axi-poll-signal-e2e-dvrSP2/artifact.html. This stays silent until the user sends feedback or ends the session - leave it running. If it gets killed or times out, re-run `lavish-axi poll /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/lavish-axi-poll-signal-e2e-dvrSP2/artifact.html` - queued feedback is never lost.
+
+[lavish-axi] Poll interrupted before user feedback arrived. The user may still be reviewing - re-run `lavish-axi poll /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/lavish-axi-poll-signal-e2e-dvrSP2/artifact.html` to keep waiting; queued feedback is never lost.
+--- attempt 2 ---
+closed: {"code":143,"signal":null}
+hasGuidance: true
+stderr:
+[lavish-axi] Long-polling for user feedback on /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/lavish-axi-poll-signal-e2e-dvrSP2/artifact.html. This stays silent until the user sends feedback or ends the session - leave it running. If it gets killed or times out, re-run `lavish-axi poll /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/lavish-axi-poll-signal-e2e-dvrSP2/artifact.html` - queued feedback is never lost.
+
+[lavish-axi] Poll interrupted before user feedback arrived. The user may still be reviewing - re-run `lavish-axi poll /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/lavish-axi-poll-signal-e2e-dvrSP2/artifact.html` to keep waiting; queued feedback is never lost.
+--- attempt 3 ---
+closed: {"code":143,"signal":null}
+hasGuidance: true
+stderr:
+[lavish-axi] Long-polling for user feedback on /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/lavish-axi-poll-signal-e2e-dvrSP2/artifact.html. This stays silent until the user sends feedback or ends the session - leave it running. If it gets killed or times out, re-run `lavish-axi poll /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/lavish-axi-poll-signal-e2e-dvrSP2/artifact.html` - queued feedback is never lost.
+
+[lavish-axi] Poll interrupted before user feedback arrived. The user may still be reviewing - re-run `lavish-axi poll /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/lavish-axi-poll-signal-e2e-dvrSP2/artifact.html` to keep waiting; queued feedback is never lost.
+--- attempt 100 ---
+closed: {"code":143,"signal":null}
+hasGuidance: true
+stderr:
+[lavish-axi] Long-polling for user feedback on /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/lavish-axi-poll-signal-e2e-dvrSP2/artifact.html. This stays silent until the user sends feedback or ends the session - leave it running. If it gets killed or times out, re-run `lavish-axi poll /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/lavish-axi-poll-signal-e2e-dvrSP2/artifact.html` - queued feedback is never lost.
+
+[lavish-axi] Poll interrupted before user feedback arrived. The user may still be reviewing - re-run `lavish-axi poll /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/lavish-axi-poll-signal-e2e-dvrSP2/artifact.html` to keep waiting; queued feedback is never lost.
+
+Failures: none

--- a/src/cli.js
+++ b/src/cli.js
@@ -201,15 +201,18 @@ async function pollCommand(args) {
   // The indefinite poll looks hung from the agent's side (stdout stays empty until the user
   // acts), so narrate the wait on stderr and leave re-run guidance behind if the agent's
   // harness kills the process anyway. stderr keeps the stdout JSON contract intact.
-  const waitReporter = timeoutMs ? null : startPollWaitReporter({ file: absolute });
   const onPollSignal = (signal) => {
     process.stderr.write(`\n${pollInterruptedText(absolute)}\n`);
     process.exit(signal === "SIGINT" ? 130 : 143);
   };
   if (!timeoutMs) {
+    // Register before the banner write below: a harness that kills the poll as soon as the
+    // banner appears can deliver the signal before the next statement runs, and without a
+    // handler the default disposition exits silently with no re-run guidance.
     process.on("SIGINT", onPollSignal);
     process.on("SIGTERM", onPollSignal);
   }
+  const waitReporter = timeoutMs ? null : startPollWaitReporter({ file: absolute });
   try {
     const response = await fetchJson(`${baseUrl}/api/poll?file=${encodeURIComponent(absolute)}${timeoutQuery}`, {
       retries: 3,

--- a/test/cli-output.test.js
+++ b/test/cli-output.test.js
@@ -388,9 +388,11 @@ test("spawned poll announces the wait on stderr and leaves re-run guidance when 
     });
     await sawBanner;
 
-    const exited = new Promise((resolve) => child.on("exit", (code, signal) => resolve({ code, signal })));
+    // Wait for "close" rather than "exit": "exit" can fire while the final stderr chunk is
+    // still in flight, so asserting on stderr at "exit" races the guidance message.
+    const closed = new Promise((resolve) => child.on("close", (code, signal) => resolve({ code, signal })));
     child.kill("SIGTERM");
-    await exited;
+    await closed;
 
     // Windows terminates Node child processes directly instead of delivering SIGTERM
     // to the child process's JavaScript signal handler.


### PR DESCRIPTION
## Intent

Fix the flaky macOS CI failure on main: the test 'spawned poll announces the wait on stderr and leaves re-run guidance when killed' (test/cli-output.test.js:358) intermittently saw only the waiting banner on stderr and never the 'Poll interrupted' guidance after SIGTERM. Root cause diagnosed by minimal repro: in pollCommand (src/cli.js) the waiting banner was written to stderr BEFORE the SIGINT/SIGTERM handlers were registered. The pipe write wakes the watching process immediately, so a harness (or the test) that kills the poll the moment the banner appears can deliver the signal before the next JS statement runs; the default disposition then exits silently with no guidance. Reproduced at 7/100 misses against the real CLI with a tight kill loop; 0/100 after the fix. The fix deliberately only reorders: handler registration now happens before startPollWaitReporter, with a comment explaining the ordering constraint. We considered also switching the handler's process.stderr.write to fs.writeSync for exit-safety but ruled it out as unnecessary - the repro showed the async write + process.exit path never drops the message once the handler is registered first, and writeSync on a non-blocking pipe can throw EAGAIN. The test change from awaiting the child's 'exit' event to 'close' is intentional belt-and-braces: 'exit' can fire while the final stderr chunk is still in flight, so asserting on stderr at 'exit' races the guidance message. No behavior change for users beyond the interrupted-poll guidance now reliably appearing when the process is killed. pnpm run check passes locally (175 tests).

## What Changed

- Register `lavish-axi poll` SIGINT/SIGTERM handlers before writing the indefinite-wait banner so immediate termination still emits the re-run guidance.
- Update the spawned poll interruption test to wait for the child `close` event before asserting on captured stderr, avoiding a race with the final guidance chunk.
- Add no-mistakes evidence for the tight SIGTERM loop verification that exercised the real CLI.

## Risk Assessment

✅ Low: The branch is a narrow ordering fix with a test harness synchronization improvement, and review found no material correctness, security, performance, or behavioral regressions.

## Testing

No baseline tests had already run in this worktree; after restoring missing dependencies, the focused automated regression test passed, the real CLI SIGTERM tight-loop produced 0/100 missing guidance cases, evidence was saved under the requested in-repo evidence directory, and transient `node_modules` was removed.

<details>
<summary>Evidence: Real CLI SIGTERM tight-loop transcript</summary>

Source: [Real CLI SIGTERM tight-loop transcript](https://github.com/kunchenguid/lavish-axi/blob/568aeabcb5554ba37fcf56709c7925fb35a71185/.no-mistakes/evidence/fix/poll-signal-registration-race/poll-sigterm-tight-loop-transcript.txt)

```text
100 attempts, 0 misses. Each attempt spawned the real CLI poll command, killed it immediately after the long-poll banner appeared, and observed the interrupted-poll re-run guidance on stderr.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`node --test --test-name-pattern &#34;spawned poll announces the wait on stderr and leaves re-run guidance when killed&#34; test/cli-output.test.js` (first attempt identified missing dependencies in the isolated worktree)</code>
- <code>`pnpm install` to restore project dependencies for testing, followed by rerunning the focused poll interruption test successfully</code>
- <code>`node --input-type=module &lt;&lt;&#39;NODE&#39; ... NODE` end-user verification: spawned the real `bin/lavish-axi.js poll &lt;artifact&gt;` command 100 times, killed each process with `SIGTERM` immediately after the wait banner appeared, waited for `close`, and checked stderr for interrupted-poll re-run guidance</code>
- <code>`rm -rf node_modules` to remove transient installed dependencies after testing</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
