### PR TITLE
chore: refresh vendored no-mistakes skill

### DIFF
--- a/.agents/skills/no-mistakes/SKILL.md
+++ b/.agents/skills/no-mistakes/SKILL.md
@@ -2,8 +2,6 @@
 name: no-mistakes
 description: Validate your code changes through the no-mistakes pipeline - automated code review, tests, lint, docs, push, PR, and CI - before they reach upstream. Use when the user asks to run no-mistakes, gate or ship or validate their changes, push safely, asks you to do a task and then validate it, or invokes /no-mistakes.
 user-invocable: true
-metadata:
-  internal: true
 ---
 
 # no-mistakes


### PR DESCRIPTION
Tool-generated refresh from `no-mistakes init`: drops the stale `metadata.internal` lines from the vendored skill file. No functional change.