### PR TITLE
feat(cli): tell agents to screenshot existing UI instead of describing it

### DIFF
--- a/skills/lavish/SKILL.md
+++ b/skills/lavish/SKILL.md
@@ -44,6 +44,7 @@ Use lavish-axi when the user asks for a visual artifact, HTML explainer, interac
 - Use visual structure such as sections, cards, tables, diagrams, annotated snippets, and side-by-side comparisons instead of long prose
 - Choose typography, spacing, color, and layout deliberately so the artifact has a clear point of view
 - Prevent horizontal overflow at every nesting level: nested grid/flex children also need minmax(0, 1fr) tracks and min-width: 0, especially when badges, labels, or status text use wide pixel or monospace fonts; wrap, truncate, or contain long unbreakable text deliberately
+- When the artifact would describe existing or current UI or state, show it instead: capture screenshots of the real pages (run the app read-only if needed) and embed them, rather than explaining the current look in prose; reserve prose for what cannot be shown such as rationale, trade-offs, and open questions
 
 ## Playbooks
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -119,6 +119,7 @@ export function createHomeOutput({ bin, sessions, includeSessions = true }) {
       "Use visual structure such as sections, cards, tables, diagrams, annotated snippets, and side-by-side comparisons instead of long prose",
       "Choose typography, spacing, color, and layout deliberately so the artifact has a clear point of view",
       "Prevent horizontal overflow at every nesting level: nested grid/flex children also need minmax(0, 1fr) tracks and min-width: 0, especially when badges, labels, or status text use wide pixel or monospace fonts; wrap, truncate, or contain long unbreakable text deliberately",
+      "When the artifact would describe existing or current UI or state, show it instead: capture screenshots of the real pages (run the app read-only if needed) and embed them, rather than explaining the current look in prose; reserve prose for what cannot be shown such as rationale, trade-offs, and open questions",
     ],
     playbooks: listPlaybooks(),
     help: [

--- a/test/cli-output.test.js
+++ b/test/cli-output.test.js
@@ -54,8 +54,11 @@ test("home output teaches agents when and how to use Lavish Editor", () => {
   assert.equal("use_cases" in output, false);
   assert.equal("example_use_cases" in output, false);
   assert.equal("artifact_guidance" in output, false);
-  assert.ok(output.visual_guidance.length <= 4);
+  assert.ok(output.visual_guidance.length <= 5);
   assert.ok(output.visual_guidance.some((item) => item.includes("visual hierarchy")));
+  assert.ok(
+    output.visual_guidance.some((item) => /screenshot/i.test(item) && /embed/i.test(item) && /prose/i.test(item)),
+  );
   assert.ok(output.visual_guidance.some((item) => item.includes("sections, cards, tables")));
   assert.ok(output.visual_guidance.some((item) => item.includes("horizontal overflow")));
   assert.ok(output.visual_guidance.some((item) => item.includes("minmax(0, 1fr)")));


### PR DESCRIPTION
Adds one bullet to the agent visual_guidance (in createHomeOutput, src/cli.js): when an artifact would describe existing or current UI/state, capture screenshots of the real pages and embed them instead of describing the current look in prose; reserve prose for what cannot be shown (rationale, trade-offs, open questions).

This strengthens the existing "use visuals instead of long prose" guidance for the common "what does the current UI look like" case. skills/lavish/SKILL.md is regenerated from source via scripts/build-skill.js (the --check drift guard passes) and the cli-output snapshot test is updated. npm run check is green.