### PR TITLE
feat(cli): tell agents to screenshot existing UI instead of describing it

### DIFF
--- a/skills/lavish/SKILL.md
+++ b/skills/lavish/SKILL.md
@@ -44,6 +44,7 @@ Use lavish-axi when the user asks for a visual artifact, HTML explainer, interac
 - Use visual structure such as sections, cards, tables, diagrams, annotated snippets, and side-by-side comparisons instead of long prose
 - Choose typography, spacing, color, and layout deliberately so the artifact has a clear point of view
 - Prevent horizontal overflow at every nesting level: nested grid/flex children also need minmax(0, 1fr) tracks and min-width: 0, especially when badges, labels, or status text use wide pixel or monospace fonts; wrap, truncate, or contain long unbreakable text deliberately
+- When the artifact would describe existing or current UI or state, show it instead: capture screenshots of the real pages (run the app read-only if needed) and embed them, rather than explaining the current look in prose; reserve prose for what cannot be shown such as rationale, trade-offs, and open questions
 
 ## Playbooks
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -119,6 +119,7 @@ export function createHomeOutput({ bin, sessions, includeSessions = true }) {
       "Use visual structure such as sections, cards, tables, diagrams, annotated snippets, and side-by-side comparisons instead of long prose",
       "Choose typography, spacing, color, and layout deliberately so the artifact has a clear point of view",
       "Prevent horizontal overflow at every nesting level: nested grid/flex children also need minmax(0, 1fr) tracks and min-width: 0, especially when badges, labels, or status text use wide pixel or monospace fonts; wrap, truncate, or contain long unbreakable text deliberately",
+      "When the artifact would describe existing or current UI or state, show it instead: capture screenshots of the real pages (run the app read-only if needed) and embed them, rather than explaining the current look in prose; reserve prose for what cannot be shown such as rationale, trade-offs, and open questions",
     ],
     playbooks: listPlaybooks(),
     help: [

--- a/test/cli-output.test.js
+++ b/test/cli-output.test.js
@@ -54,8 +54,11 @@ test("home output teaches agents when and how to use Lavish Editor", () => {
   assert.equal("use_cases" in output, false);
   assert.equal("example_use_cases" in output, false);
   assert.equal("artifact_guidance" in output, false);
-  assert.ok(output.visual_guidance.length <= 4);
+  assert.ok(output.visual_guidance.length <= 5);
   assert.ok(output.visual_guidance.some((item) => item.includes("visual hierarchy")));
+  assert.ok(
+    output.visual_guidance.some((item) => /screenshot/i.test(item) && /embed/i.test(item) && /prose/i.test(item)),
+  );
   assert.ok(output.visual_guidance.some((item) => item.includes("sections, cards, tables")));
   assert.ok(output.visual_guidance.some((item) => item.includes("horizontal overflow")));
   assert.ok(output.visual_guidance.some((item) => item.includes("minmax(0, 1fr)")));


### PR DESCRIPTION
## Intent

The developer wanted to add a single visualization-first instruction to lavish-axi's agent guidance, telling agents to prefer showing existing or current UI via embedded screenshots (running the app read-only if needed) over describing it in prose, while reserving prose for rationale, trade-offs, and open questions. They required the edit be made in exactly one source-of-truth location — the visual_guidance array in createHomeOutput() in src/cli.js — then regenerate skills/lavish/SKILL.md via scripts/build-skill.js (never hand-editing it) so the build-skill.js --check drift guard passes, with no other guidance edits or unrelated changes. They required updating the snapshot/assertion tests covering the home output and skill text (test/cli-output.test.js, test/skill.test.js) so the suite passes via pnpm, with automated tests covering each acceptance scenario. Process constraints included working only in the isolated worktree, branching as fm/lavish-viz-q7, targeting their fork's main rather than the upstream kunchenguid repo, and validating through the no-mistakes pipeline. During validation, the developer directed resolving a gate quirk by deleting and re-pushing the stale remote branch and re-running axi run, explicitly instructing not to run no-mistakes update.

## What Changed

- Added a new entry to the `visual_guidance` array in `createHomeOutput()` (`src/cli.js`) instructing agents to embed screenshots of real/current UI (running the app read-only if needed) instead of explaining the existing look in prose, reserving prose for rationale, trade-offs, and open questions.
- Regenerated `skills/lavish/SKILL.md` from the shared home output so the build-skill drift check stays clean.
- Updated `test/cli-output.test.js` assertions to cover the new screenshot-over-prose guidance entry.

## Risk Assessment

✅ Low: [claude] A single additive guidance string was added to the source-of-truth array, correctly mirrored into the generated skill file, and covered by an updated test, with no functional or behavioral risk.; [codex] The change is tightly scoped to adding one guidance bullet in the home output, regenerating the derived skill text, and extending the relevant home-output assertion, with no runtime control-flow or data-handling changes.

## Testing

Installed missing deps, then ran the home-output and skill test files (all 56 pass, including the updated assertions for the new fifth visual_guidance entry) and the build-skill `--check` drift guard (clean). For end-user evidence I ran the source CLI with no args and confirmed the new "show existing UI via screenshots instead of describing it in prose" instruction renders as item 5 in the agent-facing `visual_guidance` block, and verified the same line in the generated SKILL.md Visual guidance section. This change is agent-facing CLI/skill guidance text, not a rendered visual UI, so the appropriate product-level artifacts are the captured CLI transcript and rendered skill markdown rather than a screenshot. Working tree left clean.

<details>
<summary>Evidence: Live CLI agent-facing home output (visual_guidance block)</summary>

`visual_guidance[5]: ...,"When the artifact would describe existing or current UI or state, show it instead: capture screenshots of the real pages (run the app read-only if needed) and embed them, rather than explaining the current look in prose; reserve prose for what cannot be shown such as rationale, trade-offs, and open questions"`

```text
visual_guidance[5]: "Use visual hierarchy to make the most important decisions, risks, tradeoffs, and next actions obvious at a glance","Use visual structure such as sections, cards, tables, diagrams, annotated snippets, and side-by-side comparisons instead of long prose","Choose typography, spacing, color, and layout deliberately so the artifact has a clear point of view","Prevent horizontal overflow at every nesting level: nested grid/flex children also need minmax(0, 1fr) tracks and min-width: 0, especially when badges, labels, or status text use wide pixel or monospace fonts; wrap, truncate, or contain long unbreakable text deliberately","When the artifact would describe existing or current UI or state, show it instead: capture screenshots of the real pages (run the app read-only if needed) and embed them, rather than explaining the current look in prose; reserve prose for what cannot be shown such as rationale, trade-offs, and open questions"
```
</details>
<details>
<summary>Evidence: Generated SKILL.md — Visual guidance section</summary>

```text
=== Generated skill (skills/lavish/SKILL.md) Visual guidance section ===
## Visual guidance

- Use visual hierarchy to make the most important decisions, risks, tradeoffs, and next actions obvious at a glance
- Use visual structure such as sections, cards, tables, diagrams, annotated snippets, and side-by-side comparisons instead of long prose
- Choose typography, spacing, color, and layout deliberately so the artifact has a clear point of view
- Prevent horizontal overflow at every nesting level: nested grid/flex children also need minmax(0, 1fr) tracks and min-width: 0, especially when badges, labels, or status text use wide pixel or monospace fonts; wrap, truncate, or contain long unbreakable text deliberately
- When the artifact would describe existing or current UI or state, show it instead: capture screenshots of the real pages (run the app read-only if needed) and embed them, rather than explaining the current look in prose; reserve prose for what cannot be shown such as rationale, trade-offs, and open questions

## Playbooks
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pnpm install --frozen-lockfile (deps were missing in worktree)`
- `node --test test/cli-output.test.js test/skill.test.js (56 tests pass, incl. updated visual_guidance length<=5 + screenshot/embed/prose assertions and skill mirrors-home-output test)`
- `node scripts/build-skill.js --check (SKILL.md up to date — no drift)`
- `node bin/lavish-axi.js (no-args) — captured live agent-facing home output showing visual_guidance[5] with the new screenshot-over-prose instruction`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
