### PR TITLE
fix: keep internal design skill out of public listings

### DIFF
--- a/.agents/skills/lavish-design/README.md
+++ b/.agents/skills/lavish-design/README.md
@@ -3,6 +3,7 @@
 > _For when a rich editor is not rich enough._
 
 This is the brand & design system for **Lavish** — an in-browser agentic editor that opens agent-generated HTML artifacts in a local browser, lets a human pinpoint elements or selected text, annotate them, and ship that feedback back to the agent.
+Repository maintainers keep this as an internal Agent Skill, hidden from default `npx skills add ... --list` and skills.sh discovery by the `metadata.internal: true` frontmatter in `SKILL.md`.
 
 The product feels like a quiet reading room with a brass lamp: dark ink walls, a single warm gold accent, generous type set in a literary serif beside a clean technical sans. Elegant. Minimal. Futuristic. _Lavish._
 

--- a/.no-mistakes/evidence/fm/lavish-design-internal-k2/skills-list-default.txt
+++ b/.no-mistakes/evidence/fm/lavish-design-internal-k2/skills-list-default.txt
@@ -2,7 +2,7 @@
 │
 ●   codex  Agent detected — installing non-interactively
 [?25l│
-◇  Source: /Users/kunchen/.no-mistakes/worktrees/ea3c5e639a16/01KWMJ8S9NSSMZGTHVX2YEVYKW
+◇  Source: /Users/kunchen/.no-mistakes/worktrees/ea3c5e639a16/01KWMK1AWV938CW2TQ3FJ3VK77
 [?25h[?25l│
 ◇  Local path validated
 [?25h[?25l│

--- a/.no-mistakes/evidence/fm/lavish-design-internal-k2/skills-list-default.txt
+++ b/.no-mistakes/evidence/fm/lavish-design-internal-k2/skills-list-default.txt
@@ -17,4 +17,3 @@
 
 │
 └  Use --skill <name> to install specific skills
-

--- a/.no-mistakes/evidence/fm/lavish-design-internal-k2/skills-list-internal-enabled.txt
+++ b/.no-mistakes/evidence/fm/lavish-design-internal-k2/skills-list-internal-enabled.txt
@@ -21,4 +21,3 @@
 
 │
 └  Use --skill <name> to install specific skills
-

--- a/.no-mistakes/evidence/fm/lavish-design-internal-k2/skills-list-internal-enabled.txt
+++ b/.no-mistakes/evidence/fm/lavish-design-internal-k2/skills-list-internal-enabled.txt
@@ -2,7 +2,7 @@
 │
 ●   codex  Agent detected — installing non-interactively
 [?25l│
-◇  Source: /Users/kunchen/.no-mistakes/worktrees/ea3c5e639a16/01KWMJ8S9NSSMZGTHVX2YEVYKW
+◇  Source: /Users/kunchen/.no-mistakes/worktrees/ea3c5e639a16/01KWMK1AWV938CW2TQ3FJ3VK77
 [?25h[?25l│
 ◇  Local path validated
 [?25h[?25l│

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,7 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
 - Node 22+, ESM-only JavaScript, and TypeScript `checkJs` validation.
 - Run `pnpm run check` before pushing.
 - Do not reformat repo-provided `.agents/` skill content; `.prettierignore` excludes it intentionally.
+- Keep `.agents/skills/lavish-design/SKILL.md` marked with `metadata.internal: true`; it is a maintainer-only brand skill and must not become part of public skill discovery.
 - Do not hand-edit `CHANGELOG.md` or `.release-please-manifest.json`.
 - User-facing telemetry docs should stay minimal: anonymous usage telemetry, no sensitive content, and `LAVISH_AXI_TELEMETRY=0` opt-out.
 

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ For flows, architecture, state, or sequence diagrams, open the diagram playbook 
 ```sh
 pnpm run check          # Run all verification commands
 pnpm run build          # Bundle the publishable CLI, chrome, and design assets
-pnpm run build:skill    # Regenerate the installable lavish skill
+pnpm run build:skill    # Regenerate the public installable lavish skill
 pnpm test               # Run node:test tests
 pnpm run lint           # Run ESLint
 pnpm run format:check   # Check Prettier formatting

--- a/scripts/build-skill.js
+++ b/scripts/build-skill.js
@@ -1,5 +1,5 @@
-// Generates skills/lavish/SKILL.md from the shared no-args home output so the
-// installable skill never drifts from what `lavish-axi` (and the SessionStart hook) print.
+// Generates the public skills/lavish/SKILL.md from the shared no-args home output so the
+// public installable skill never drifts from what `lavish-axi` (and the SessionStart hook) print.
 //
 //   node scripts/build-skill.js          # write the file
 //   node scripts/build-skill.js --check  # fail (exit 1) if the committed file is stale

--- a/src/skill.js
+++ b/src/skill.js
@@ -21,7 +21,7 @@ function skillCommandText(text) {
 }
 
 /**
- * Render the installable SKILL.md for the lavish skill. The body mirrors what
+ * Render the public installable SKILL.md for the lavish skill. The body mirrors what
  * `lavish-axi` prints with no arguments (minus live session state), while the
  * frontmatter adds discovery metadata for Agent Skills and Hermes Agent.
  *

--- a/test/package-json.test.js
+++ b/test/package-json.test.js
@@ -2,6 +2,36 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 
+function extractFrontmatter(markdown) {
+  const end = markdown.indexOf("\n---\n", 4);
+
+  assert.ok(markdown.startsWith("---\n"), "starts with frontmatter fence");
+  assert.ok(end > 0, "frontmatter is closed");
+
+  return markdown.slice(4, end);
+}
+
+function frontmatterHasInternalMetadata(frontmatter) {
+  const lines = frontmatter.split("\n");
+  const metadataIndex = lines.findIndex((line) => line === "metadata:");
+
+  if (metadataIndex === -1) {
+    return false;
+  }
+
+  for (const line of lines.slice(metadataIndex + 1)) {
+    if (!line.startsWith(" ")) {
+      return false;
+    }
+
+    if (line === "  internal: true") {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 test("check script runs all verification commands", async () => {
   const packageJson = JSON.parse(await readFile(new URL("../package.json", import.meta.url), "utf8"));
   const checkCommands = packageJson.scripts.check.split(" && ");
@@ -31,17 +61,25 @@ test("published package includes the installable skill", async () => {
 
 test("lavish-design agent skill is marked internal for skills CLI discovery", async () => {
   const skillMd = await readFile(new URL("../.agents/skills/lavish-design/SKILL.md", import.meta.url), "utf8");
-  const frontmatter = skillMd.slice(4, skillMd.indexOf("\n---\n", 4));
+  const frontmatter = extractFrontmatter(skillMd);
 
   assert.match(frontmatter, /^name: lavish-design$/m);
-  assert.match(frontmatter, /^metadata:\n {2}internal: true$/m);
+  assert.equal(frontmatterHasInternalMetadata(frontmatter), true);
 });
 
 test("public lavish skill is not marked internal", async () => {
   const skillMd = await readFile(new URL("../skills/lavish/SKILL.md", import.meta.url), "utf8");
-  const frontmatter = skillMd.slice(4, skillMd.indexOf("\n---\n", 4));
+  const frontmatter = extractFrontmatter(skillMd);
 
-  assert.doesNotMatch(frontmatter, /^metadata:\n {2}internal: true$/m);
+  assert.equal(frontmatterHasInternalMetadata(frontmatter), false);
+});
+
+test("public skill internal guard scans the whole metadata block", () => {
+  const frontmatter = ["name: lavish", "metadata:", "  hermes:", "    category: productivity", "  internal: true"].join(
+    "\n",
+  );
+
+  assert.equal(frontmatterHasInternalMetadata(frontmatter), true);
 });
 
 test("build copies local design assets for published artifact injection", async () => {


### PR DESCRIPTION
## What Changed

- Marked the repo-local `lavish-design` skill as internal in docs and agent guidance, with visibility limited to `INSTALL_INTERNAL_SKILLS=1` listings.
- Updated public skill generation so the shipped `lavish` skill does not receive internal-only metadata.
- Added regression coverage and saved skills-list evidence for default vs internal-enabled skill discovery.

## Risk Assessment

✅ Low: The changes are limited to documentation, committed evidence, and narrow regression tests around existing skill frontmatter with no product code behavior changes.

## Testing

Inspected the branch diff to confirm the intent, regenerated reviewer-visible CLI transcripts showing default discovery lists only `lavish` while `INSTALL_INTERNAL_SKILLS=1` lists both `lavish` and `lavish-design`, ran the targeted package metadata test file successfully, and confirmed the only remaining worktree changes are the intended evidence transcript updates.

- Evidence: [Default skills discovery transcript](https://github.com/kunchenguid/lavish-axi/blob/a2eb1865c45c0d751c733c00cfd4889d0b37342e/.no-mistakes/evidence/fm/lavish-design-internal-k2/skills-list-default.txt)
- Evidence: [Internal skills opt-in discovery transcript](https://github.com/kunchenguid/lavish-axi/blob/a2eb1865c45c0d751c733c00cfd4889d0b37342e/.no-mistakes/evidence/fm/lavish-design-internal-k2/skills-list-internal-enabled.txt)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `test/package-json.test.js:44` - The public-skill guard only rejects `metadata:\n  internal: true` when `internal` is the first metadata entry. Since the generated `lavish` skill already has `metadata.hermes`, a future accidental `metadata:\n  hermes: ...\n  internal: true` would still pass even though the public skill became internal. Check for a top-level `  internal: true` entry anywhere in the frontmatter, or parse the frontmatter structure.

🔧 Fix: Tighten public skill internal guard
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --stat e2954503e11d334bf2135f7c64902ea59056ec33..77f8df15008a4e5c8325c85bfc95be5a88c885b7` and related diff reads to extract the change intent</code>
- `npx -y skills add "$PWD" --list > .no-mistakes/evidence/fm/lavish-design-internal-k2/skills-list-default.txt`
- `INSTALL_INTERNAL_SKILLS=1 npx -y skills add "$PWD" --list > .no-mistakes/evidence/fm/lavish-design-internal-k2/skills-list-internal-enabled.txt`
- `node --test test/package-json.test.js`
- <code>`sed -n &#39;1,140p&#39; .no-mistakes/evidence/fm/lavish-design-internal-k2/skills-list-default.txt` and `sed -n &#39;1,170p&#39; .no-mistakes/evidence/fm/lavish-design-internal-k2/skills-list-internal-enabled.txt` to verify the saved transcripts</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
