### PR TITLE
fix(chrome): add conversation empty state

### DIFF
--- a/skills/lavish/SKILL.md
+++ b/skills/lavish/SKILL.md
@@ -32,6 +32,7 @@ Use lavish-axi when the user asks for a visual artifact, HTML explainer, interac
 1. Create the HTML artifact (default location `.lavish/<name>.html` in the working directory).
 2. Run `npx -y lavish-axi <html-file>` to open or resume a review session in the browser.
 3. Run `npx -y lavish-axi poll <html-file>` to long-poll for the user's annotations, queued prompts, and browser-reported `layout_warnings`.
+   On the first poll, prefer `--agent-reply "<one-line summary of what you built and what to review first>"` so the conversation panel opens with context.
    The poll stays silent until the user acts or the real browser reports fresh layout warnings - leave it running, never kill it.
    If your harness limits how long a foreground command may run, run the poll as a background task; if it gets killed or times out anyway, just re-run it - queued feedback is never lost.
 4. If poll returns `layout_warnings`, follow the returned `next_step`: fix and re-check fresh error-severity findings, but proceed with a note instead of looping when every current warning is persistent or low-severity.

--- a/src/chrome.css
+++ b/src/chrome.css
@@ -652,6 +652,14 @@ body.lavish {
   flex-direction: column;
   gap: 10px;
 }
+
+.chat:empty::before {
+  content: "Agent hasn't sent a message yet. Click an element in the artifact to annotate, or type below to start.";
+  margin-top: 2px;
+  color: var(--fg-muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
 .bubble {
   max-width: 85%;
   border-radius: var(--radius-xl);

--- a/src/skill.js
+++ b/src/skill.js
@@ -64,6 +64,7 @@ ${home.help[home.help.length - 1]}
 1. Create the HTML artifact (default location \`.lavish/<name>.html\` in the working directory).
 2. Run \`npx -y lavish-axi <html-file>\` to open or resume a review session in the browser.
 3. Run \`npx -y lavish-axi poll <html-file>\` to long-poll for the user's annotations, queued prompts, and browser-reported \`layout_warnings\`.
+   On the first poll, prefer \`--agent-reply "<one-line summary of what you built and what to review first>"\` so the conversation panel opens with context.
    The poll stays silent until the user acts or the real browser reports fresh layout warnings - leave it running, never kill it.
    If your harness limits how long a foreground command may run, run the poll as a background task; if it gets killed or times out anyway, just re-run it - queued feedback is never lost.
 4. If poll returns \`layout_warnings\`, follow the returned \`next_step\`: fix and re-check fresh error-severity findings, but proceed with a note instead of looping when every current warning is persistent or low-severity.

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -560,6 +560,9 @@ test("chrome includes a chat-like prompt composer and agent reply listener", asy
   const js = await chromeClientSource();
 
   assert.match(html, /id="chatLog"/);
+  const css = await chromeCssSource();
+  assert.match(css, /\.chat:empty::before\{/);
+  assert.match(css, /Agent hasn't sent a message yet/);
   assert.match(html, /id="chatInput"/);
   assert.match(js, /agent-reply/);
 });


### PR DESCRIPTION
## Intent

Resolve lavish-axi issue #104 exactly and only: add the requested conversation empty state and the requested SKILL opening-message convention. Scope is intentionally four files only: src/chrome.css for .chat:empty::before copy, skills/lavish/SKILL.md and generated src/skill.js for first-poll --agent-reply guidance, and test/server.test.js for minimal CSS coverage. Do not add CLI next_step changes, README/AGENTS docs, memory files, Windows symlink hygiene, export tests, #118/wheelhouse/quick-prompt work, or unrelated files. Manual checks already run: Prettier on changed files, ESLint on changed JS files, TypeScript noEmit, build, build-skill --check, focused server test, and before/after Chrome screenshots.

## What Changed
- Added an empty-state hint to the conversation log so the browser chrome shows guidance before any messages exist.
- Updated the generated Lavish skill guidance to tell agents to use `--agent-reply` for the first poll so the opening message appears in the browser.
- Covered the empty-state CSS in the existing chrome/server test fixture.

## Risk Assessment

✅ Low: Small, well-bounded CSS/guidance/test update with no material correctness, security, or simplification issues found.

## Testing

After restoring missing dependencies, the focused server test and generated-skill drift check passed; an actual Lavish session in headless Chrome showed the requested empty conversation message and produced screenshot evidence, with transient `node_modules`/`dist` cleaned from the worktree.

- Evidence: Conversation empty-state in actual Lavish chrome (local file: <code>X:\android-home\tmp\no-mistakes-evidence\01KX0NZHJ1T56VNFRZFHGP85BD\conversation-empty-state.png</code>)
<details>
<summary>Evidence: Generated SKILL first-poll guidance excerpt</summary>

<code>On the first poll, prefer `--agent-reply &#34;&lt;one-line summary of what you built and what to review first&gt;&#34;` so the conversation panel opens with context.</code>

```text
On the first poll, prefer `--agent-reply "<one-line summary of what you built and what to review first>"` so the conversation panel opens with context.
```
</details>
<details>
<summary>Evidence: Evidence manifest</summary>

```text
{
  "sessionUrl": "http://127.0.0.1:57779/session/c21f6c17c1341b13?no-gate=1",
  "screenshotPath": "X:\\android-home\\tmp\\no-mistakes-evidence\\01KX0NZHJ1T56VNFRZFHGP85BD\\conversation-empty-state.png",
  "skillExcerptPath": "X:\\android-home\\tmp\\no-mistakes-evidence\\01KX0NZHJ1T56VNFRZFHGP85BD\\generated-skill-first-poll-excerpt.txt",
  "emptyStatePseudoContent": "\"Agent hasn't sent a message yet. Click an element in the artifact to annotate, or type below to start.\""
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Initial `node --test --test-name-pattern &#34;chrome includes a chat-like prompt composer and agent reply listener&#34; test/server.test.js` exposed missing local deps (`chokidar`).</code>
- <code>`pnpm install --frozen-lockfile` to restore project deps for testing; removed generated `node_modules` and `dist` afterward.</code>
- `node --test --test-name-pattern "chrome includes a chat-like prompt composer and agent reply listener" test/server.test.js`
- `node scripts/build-skill.js --check`
- <code>`node X:\android-home\tmp\no-mistakes-evidence\01KX0NZHJ1T56VNFRZFHGP85BD\capture-empty-state.mjs` to start the source server, create a session, assert the `#chatLog::before` content, capture Chrome screenshot, and write the generated skill excerpt.</code>
- <code>Reviewed `X:\android-home\tmp\no-mistakes-evidence\01KX0NZHJ1T56VNFRZFHGP85BD\conversation-empty-state.png` visually.</code>

</details>

<details>
<summary>⏭️ **Document** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
