### PR TITLE
fix(server): block DNS rebinding and cross-origin CSRF on loopback server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,8 +146,8 @@ No need to explicitly document the telemetry behaviors.
 ## Things to know when editing
 
 - Two global middlewares in `serve()` guard the loopback server and run before every route; keep them ordered Host-guard-then-origin-guard and do not let a new route slip in ahead of them.
-  The Host allowlist (`allowedHostSet`/`isAllowedHost`) is the primary DNS-rebinding defense: it 403s any request whose `Host` host-part is not a loopback name or the operator-configured `LAVISH_AXI_HOST`/`LAVISH_AXI_LINK_HOST`, because a rebound request still carries the attacker's hostname in `Host`.
-  The mutating-route guard (`hasForeignOrigin`) 403s any non-GET request that arrives with a *present* foreign `Origin`/`Referer`; it deliberately allows header-less requests because the CLI control channel dials the server with no `Origin`, relying on the Host allowlist instead - so never tighten it to reject absent headers.
+  The Host allowlist (`buildAllowedHostnames`/`isAllowedRequestHost`) is the primary DNS-rebinding defense: it 403s any request whose `Host` host-part is not a loopback name or the operator-configured `LAVISH_AXI_HOST`/`LAVISH_AXI_LINK_HOST`/`LAVISH_AXI_ALLOWED_HOSTS` extras, because a rebound request still carries the attacker's hostname in `Host`.
+  The mutating-route guard (`hasForeignOrigin`) 403s any non-GET request that arrives with a _present_ foreign `Origin`/`Referer`; it deliberately allows header-less requests because the CLI control channel dials the server with no `Origin`, relying on the Host allowlist instead - so never tighten it to reject absent headers.
   `/share`, `/whiteboard-channel`, and the whiteboard write routes keep their own stricter `isSameOriginRequest` (rejects even header-less requests) and are exempted from the lenient guard via `isStrictlyGuardedPath`; add any new stricter-guarded path there too so the lenient guard cannot shadow it.
 - `canonicalFile` runs `realpath`, so symlinks resolve to their target before becoming session keys. Two paths that refer to the same file always collapse to one session.
 - The SDK injected into artifacts lives in `src/artifact-sdk.js` and is wrapped by `createSdkJs`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,10 @@ No need to explicitly document the telemetry behaviors.
 
 ## Things to know when editing
 
+- Two global middlewares in `serve()` guard the loopback server and run before every route; keep them ordered Host-guard-then-origin-guard and do not let a new route slip in ahead of them.
+  The Host allowlist (`allowedHostSet`/`isAllowedHost`) is the primary DNS-rebinding defense: it 403s any request whose `Host` host-part is not a loopback name or the operator-configured `LAVISH_AXI_HOST`/`LAVISH_AXI_LINK_HOST`, because a rebound request still carries the attacker's hostname in `Host`.
+  The mutating-route guard (`hasForeignOrigin`) 403s any non-GET request that arrives with a *present* foreign `Origin`/`Referer`; it deliberately allows header-less requests because the CLI control channel dials the server with no `Origin`, relying on the Host allowlist instead - so never tighten it to reject absent headers.
+  `/share`, `/whiteboard-channel`, and the whiteboard write routes keep their own stricter `isSameOriginRequest` (rejects even header-less requests) and are exempted from the lenient guard via `isStrictlyGuardedPath`; add any new stricter-guarded path there too so the lenient guard cannot shadow it.
 - `canonicalFile` runs `realpath`, so symlinks resolve to their target before becoming session keys. Two paths that refer to the same file always collapse to one session.
 - The SDK injected into artifacts lives in `src/artifact-sdk.js` and is wrapped by `createSdkJs`.
   It executes inside an iframe sandboxed with `allow-scripts allow-forms allow-popups allow-downloads` (no `allow-same-origin`), so it cannot read the chrome's DOM - communication is `postMessage` only - and it runs the layout audit in the iframe because the chrome cannot directly inspect the sandboxed document.

--- a/src/server.js
+++ b/src/server.js
@@ -905,8 +905,9 @@ function encodeRfc5987Value(value) {
 
 // Wildcard bind addresses ("all interfaces") are not connectable hostnames, so
 // they never belong in the Host allowlist - and "0.0.0.0" as a Host is a known
-// loopback-reach trick, so it must stay rejected.
-const WILDCARD_BIND_HOSTS = new Set(["0.0.0.0", "::"]);
+// loopback-reach trick, so it must stay rejected. Both the bare ("::") and
+// bracketed ("[::]") IPv6 wildcard forms are excluded.
+const WILDCARD_BIND_HOSTS = new Set(["0.0.0.0", "::", "[::]"]);
 
 // The set of Host header hostnames this server answers to: loopback names plus
 // the resolved bind and link host and any explicit LAVISH_AXI_ALLOWED_HOSTS

--- a/src/server.js
+++ b/src/server.js
@@ -172,6 +172,27 @@ export async function serve({
     });
   }
 
+  // CSRF / same-origin defense for state-changing routes (defense-in-depth on
+  // top of the Host guard). A cross-origin page hitting the loopback server
+  // directly passes the Host check but the browser attaches its real foreign
+  // Origin, so we reject any mutating request that arrives with a present,
+  // non-matching Origin/Referer. Header-less requests (the CLI control channel
+  // dials the server with no Origin) are allowed and rely on the Host allowlist.
+  // Routes that publish or write outside the session (/share, whiteboard writes)
+  // keep their own stricter isSameOriginRequest check, which also rejects the
+  // header-less case, so they are exempt here to preserve that behavior.
+  app.use((req, res, next) => {
+    if (!isMutatingMethod(req.method) || isStrictlyGuardedPath(req.method, req.path)) {
+      next();
+      return;
+    }
+    if (hasForeignOrigin(req)) {
+      res.status(403).json({ error: "cross-origin request rejected" });
+      return;
+    }
+    next();
+  });
+
   const defaultJsonParser = express.json({ limit: "2mb" });
   const whiteboardJsonParser = express.json({ limit: "20mb" });
   app.use((req, res, next) =>
@@ -960,6 +981,34 @@ export function isAllowedRequestHost({ host, forwardedHost }, allowedHostnames) 
   const forwarded = forwardedHost === undefined || forwardedHost === null ? "" : String(forwardedHost).trim();
   if (forwarded === "") return true;
   return isAllowedHostHeader(forwarded.split(",").pop(), allowedHostnames);
+}
+
+function isMutatingMethod(method) {
+  return method !== "GET" && method !== "HEAD" && method !== "OPTIONS";
+}
+
+// Routes that enforce their own stricter isSameOriginRequest (reject even
+// header-less requests) so the lenient global mutating guard must not shadow or
+// weaken them. GET routes are never mutating, so only the write verbs matter.
+function isStrictlyGuardedPath(method, pathname) {
+  const p = String(pathname || "");
+  if (method === "POST" && /^\/api\/[0-9a-f]{16}\/share$/.test(p)) return true;
+  if (method === "POST" && /^\/api\/[0-9a-f]{16}\/whiteboard-channel$/.test(p)) return true;
+  if ((method === "PUT" || method === "POST") && isWhiteboardWriteApiPath(p)) return true;
+  return false;
+}
+
+// True only when a browser attached an Origin (or Referer) that resolves to a
+// different origin than this server. A missing header returns false so the CLI
+// control channel (no Origin) is not blocked; the Host allowlist is the gate for
+// header-less requests.
+function hasForeignOrigin(req) {
+  const expectedOrigin = `${req.protocol}://${req.get("host")}`;
+  const origin = req.get("origin");
+  if (origin) return normalizeOrigin(origin) !== expectedOrigin;
+  const referer = req.get("referer");
+  if (referer) return normalizeOrigin(referer) !== expectedOrigin;
+  return false;
 }
 
 // Guard state-changing, outward-facing routes (publishing to a third-party host) against CSRF: a

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1826,6 +1826,87 @@ test("POST /api/:key/share rejects requests without provenance headers", async (
   }
 });
 
+test("rejects requests whose Host header is not a loopback name (DNS-rebinding guard)", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "lavish-serve-"));
+  const artifact = path.join(dir, "artifact.html");
+  await writeFile(artifact, "<!doctype html><html><body></body></html>");
+  const server = await serve({ port: 0, stateFile: path.join(dir, "state.json"), version: "9.9.9-test" });
+  try {
+    const key = sessionKey(await canonicalFile(artifact));
+    // A rebound page drives the loopback server but its Host header still names
+    // the attacker's original hostname - the primary rebinding defense rejects it.
+    const rebound = await rawRequest(server.port, `/api/${key}/prompts`, {
+      method: "POST",
+      host: "evil.com",
+      body: JSON.stringify({ prompts: [{ text: "malicious" }] }),
+    });
+    assert.equal(rebound.status, 403);
+    assert.deepEqual(JSON.parse(rebound.body), { error: "forbidden host" });
+
+    // The guard is port-agnostic and covers every route, including reads.
+    const health = await rawRequest(server.port, "/health", { host: "attacker.example:1234" });
+    assert.equal(health.status, 403);
+
+    // Legitimate loopback hostnames still pass the guard.
+    for (const host of ["127.0.0.1", "localhost", "[::1]"]) {
+      const ok = await rawRequest(server.port, "/health", { host: `${host}:${server.port}` });
+      assert.equal(ok.status, 200, `expected ${host} to pass the host guard`);
+    }
+  } finally {
+    await server.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("POST /api/:key/prompts rejects a cross-origin browser request", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "lavish-serve-"));
+  const artifact = path.join(dir, "artifact.html");
+  await writeFile(artifact, "<!doctype html><html><body></body></html>");
+  const server = await serve({ port: 0, stateFile: path.join(dir, "state.json"), version: "9.9.9-test" });
+  try {
+    const base = `http://127.0.0.1:${server.port}`;
+    const sessionRes = await fetch(`${base}/api/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ file: artifact }),
+    });
+    const session = await sessionRes.json();
+
+    // A malicious page loaded from another origin can reach the loopback server
+    // (Host passes because the socket resolves to 127.0.0.1) but the browser
+    // attaches the real foreign Origin, so the mutating guard rejects it.
+    const crossOrigin = await fetch(`${base}/api/${session.key}/prompts`, {
+      method: "POST",
+      headers: { "content-type": "application/json", origin: "https://attacker.example" },
+      body: JSON.stringify({ prompts: [{ text: "injected" }] }),
+    });
+    assert.equal(crossOrigin.status, 403);
+    assert.deepEqual(await crossOrigin.json(), { error: "cross-origin request rejected" });
+
+    // The legitimate same-origin browser request still queues the prompt.
+    const sameOrigin = await fetch(`${base}/api/${session.key}/prompts`, {
+      method: "POST",
+      headers: { "content-type": "application/json", origin: base },
+      body: JSON.stringify({ prompts: [{ text: "legit" }] }),
+    });
+    assert.equal(sameOrigin.status, 200);
+    assert.equal((await sameOrigin.json()).status, "queued");
+
+    // The CLI control channel dials the loopback server with no Origin/Referer
+    // and must keep working - the mutating guard only rejects a present, foreign
+    // origin, leaning on the Host allowlist for header-less requests.
+    const cliOpen = await fetch(`${base}/api/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ file: artifact }),
+    });
+    assert.equal(cliOpen.status, 200);
+  } finally {
+    await server.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("POST /shutdown stops the listener so the client can spawn a fresh server", async () => {
   const dir = await mkdtemp(path.join(tmpdir(), "lavish-serve-"));
   const server = await serve({ port: 0, stateFile: path.join(dir, "state.json"), version: "9.9.9-test" });

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1840,6 +1840,16 @@ test("allows a custom bare IPv6 LAVISH_AXI_HOST to match its bracketed Host head
   assert.equal(isAllowedHostHeader("evil.com", allowed), false);
 });
 
+test("never widens the allowlist for a wildcard bind (IPv4 or IPv6 sentinel)", () => {
+  const loopbackOnly = new Set(["127.0.0.1", "::1", "localhost"]);
+  for (const wildcard of ["0.0.0.0", "::", "[::]", " :: "]) {
+    const allowed = buildAllowedHostnames({ host: wildcard, linkHost: wildcard });
+    assert.deepEqual([...allowed].sort(), [...loopbackOnly].sort());
+    assert.equal(isAllowedHostHeader("[::]:8080", allowed), false);
+    assert.equal(isAllowedHostHeader("0.0.0.0:8080", allowed), false);
+  }
+});
+
 test("rejects requests whose Host header is not a loopback name (DNS-rebinding guard)", async () => {
   const dir = await mkdtemp(path.join(tmpdir(), "lavish-serve-"));
   const artifact = path.join(dir, "artifact.html");

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1826,6 +1826,20 @@ test("POST /api/:key/share rejects requests without provenance headers", async (
   }
 });
 
+test("allows a custom bare IPv6 LAVISH_AXI_HOST to match its bracketed Host header", () => {
+  const literal = "2001:db8::1";
+  const allowed = buildAllowedHostnames({ host: literal, linkHost: "127.0.0.1" });
+  // Stored bare (unbracketed) so a bracketed browser Host still resolves to it.
+  assert.ok(allowed.has(literal));
+  // The bracketed authority a browser sends (`[2001:db8::1]:PORT`) passes.
+  assert.equal(isAllowedHostHeader(`[${literal}]:8080`, allowed), true);
+  // Loopback names and the co-configured link host still pass.
+  assert.equal(isAllowedHostHeader("127.0.0.1:8080", allowed), true);
+  assert.equal(isAllowedHostHeader("[::1]:8080", allowed), true);
+  // An attacker hostname is still rejected.
+  assert.equal(isAllowedHostHeader("evil.com", allowed), false);
+});
+
 test("rejects requests whose Host header is not a loopback name (DNS-rebinding guard)", async () => {
   const dir = await mkdtemp(path.join(tmpdir(), "lavish-serve-"));
   const artifact = path.join(dir, "artifact.html");


### PR DESCRIPTION
## What Changed

- Added two global middlewares in `src/server.js` that run before every route: a Host allowlist (`allowedHostSet`/`isAllowedHost`) that 403s any request whose `Host` host-part is not a loopback name or the operator-configured `LAVISH_AXI_HOST`/`LAVISH_AXI_LINK_HOST` (primary DNS-rebinding defense), and a mutating-route guard (`hasForeignOrigin`) that 403s non-GET requests carrying a present foreign `Origin`/`Referer` while still allowing header-less CLI control-channel requests.
- Normalized custom-host allowlist entries — handling bare IPv6 hosts and excluding the IPv6 wildcard — and kept the stricter same-origin routes (`/share`, `/whiteboard-channel`, whiteboard writes) exempt from the lenient guard via `isStrictlyGuardedPath`.
- Documented the Host-allowlist wildcard 403 and wildcard-bind LAN requirement in server help (`src/cli.js`), `README.md`, and `AGENTS.md`; expanded `test/server.test.js` with DNS-rebinding, cross-origin, and allowlist coverage.

## Risk Assessment

✅ Low: Well-bounded, thoroughly-tested security hardening with correct guard ordering, safe defaults, and route self-guards preserved; no material bugs found.

## Testing

Ran the full server test file (149 pass after installing deps — the only setup fix) and captured a live HTTP transcript against a real running server exercising all six security scenarios: forged Host headers (POST and GET) return 403 forbidden host header, foreign Origin returns 403 cross-origin request rejected, and the three legitimate paths (same-origin browser POST, loopback Host read, header-less CLI POST) all return 200 — matching the intended DNS-rebinding + CSRF contract. This is a server-side security change with no rendered UI, so the reviewer-visible evidence is the wire-level HTTP transcript rather than a screenshot.

<details>
<summary>Evidence: Live HTTP security transcript (Host/Origin guards)</summary>

<code>1. Forged Host attacker.example POST /api/:key/prompts -&gt; HTTP 403 (forbidden host header)&#10;2. Forged Host evil.com GET /health -&gt; HTTP 403&#10;3. Foreign Origin https://attacker.example POST -&gt; HTTP 403 (cross-origin request rejected)&#10;4. Same-origin POST -&gt; HTTP 200 {&#34;status&#34;:&#34;queued&#34;,&#34;pending_prompts&#34;:1}&#10;5. Loopback Host localhost GET /health -&gt; HTTP 200&#10;6. Header-less CLI POST /api/sessions -&gt; HTTP 200</code>

```text
=== 1. DNS-rebinding: forged Host header (attacker.example) -> expect 403 ===
HTTP/1.1 403 Forbidden
X-Powered-By: Express
Content-Type: application/json; charset=utf-8
Content-Length: 33
ETag: W/"21-Q/r2WFr22ardq9fJ1t7VUnLP66k"
Date: Tue, 14 Jul 2026 21:06:41 GMT
Connection: keep-alive
Keep-Alive: timeout=5

=== 2. DNS-rebinding on a GET read route (Host: evil.com) -> expect 403 ===
HTTP/1.1 403 Forbidden
X-Powered-By: Express
Content-Type: application/json; charset=utf-8
Content-Length: 33
ETag: W/"21-Q/r2WFr22ardq9fJ1t7VUnLP66k"
Date: Tue, 14 Jul 2026 21:06:41 GMT
Connection: keep-alive
Keep-Alive: timeout=5

=== 3. Cross-origin CSRF: foreign Origin -> expect 403 ===
HTTP/1.1 403 Forbidden
X-Powered-By: Express
Content-Type: application/json; charset=utf-8
Content-Length: 41
ETag: W/"29-d0h2CLNFLF568kIKkVe4X8iHn7o"
Date: Tue, 14 Jul 2026 21:06:41 GMT
Connection: keep-alive
Keep-Alive: timeout=5

=== 4. Legit same-origin browser POST -> expect 200 queued ===
HTTP/1.1 200 OK
X-Powered-By: Express
Content-Type: application/json; charset=utf-8
Content-Length: 39
ETag: W/"27-L2AK42r3jCAYC0WmUjYBbRTUQpE"
Date: Tue, 14 Jul 2026 21:06:41 GMT
Connection: keep-alive
Keep-Alive: timeout=5

{"status":"queued","pending_prompts":1}
=== 5. Legit loopback Host on read route -> expect 200 ===
HTTP/1.1 200 OK
X-Powered-By: Express
Content-Type: application/json; charset=utf-8
Content-Length: 49
ETag: W/"31-vODboG4AFd7lbnGRUh7SChk5R+4"
Date: Tue, 14 Jul 2026 21:06:41 GMT
Connection: keep-alive
Keep-Alive: timeout=5

=== 6. CLI control channel: no Origin header POST -> expect 200 (header-less allowed) ===
HTTP/1.1 200 OK
X-Powered-By: Express
Content-Type: application/json; charset=utf-8
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `src/server.js:936` - isStrictlyGuardedPath hardcodes the `[0-9a-f]{16}` session-key regex, which is coupled to sessionKey&#39;s `slice(0,16)` lowercase-hex output in session-store.js. If the key length or casing ever changes, the strict-route exemption silently stops matching. No security regression today (the strict routes still enforce their own isSameOriginRequest and the lenient guard would also allow the request through), but the exemption invariant would break without any signal. Consider deriving the length from a shared constant or documenting the coupling.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`node --test test/server.test.js` — 149 pass, including the new DNS-rebinding, cross-origin, and allowlist tests (required `pnpm install` first)</code>
- <code>Live HTTP transcript vs a real detached `lavish-axi server`: forged Host `attacker.example`/`evil.com` → 403 on POST and GET; foreign Origin → 403; same-origin POST → 200 queued; loopback Host → 200; header-less POST → 200</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
