### PR TITLE
fix: surface silent artifact SDK failures

### DIFF
--- a/src/artifact-sdk.js
+++ b/src/artifact-sdk.js
@@ -251,6 +251,11 @@ export function createArtifactSdk(
   isNativeInteractive = isNativeInteractiveControl,
   mermaid = mermaidHelpers,
 ) {
+  /** @type {Window & { __lavishArtifactHealth?: { markSdkStarted?: () => void, markSdkAttached?: () => void, markSdkReady?: () => void } }} */ (
+    window
+  ).__lavishArtifactHealth?.markSdkStarted?.();
+  parent.postMessage({ type: "lavish:artifactLifecycle", stage: "sdk-started" }, "*");
+
   const { isMermaidSvg, mermaidNodeFrom, mermaidNodeElement } = mermaid;
   let annotationMode = true;
   let hovered = null;
@@ -1538,6 +1543,10 @@ export function createArtifactSdk(
     setStatus: (message) => parent.postMessage({ type: "lavish:status", message: String(message) }, "*"),
     snapshot,
   };
+  /** @type {Window & { __lavishArtifactHealth?: { markSdkAttached?: () => void } }} */ (
+    window
+  ).__lavishArtifactHealth?.markSdkAttached?.();
+  parent.postMessage({ type: "lavish:artifactLifecycle", stage: "sdk-attached" }, "*");
 
   window.addEventListener("message", (event) => {
     const msg = event.data || {};
@@ -1665,4 +1674,9 @@ export function createArtifactSdk(
   }
   const mermaidObserver = new MutationObserver(() => scheduleMermaidEnhance());
   mermaidObserver.observe(document.documentElement, { childList: true, subtree: true });
+
+  /** @type {Window & { __lavishArtifactHealth?: { markSdkReady?: () => void } }} */ (
+    window
+  ).__lavishArtifactHealth?.markSdkReady?.();
+  parent.postMessage({ type: "lavish:artifactLifecycle", stage: "sdk-ready" }, "*");
 }

--- a/src/html-transform.js
+++ b/src/html-transform.js
@@ -1,7 +1,209 @@
-export function injectLavishSdk(html, key) {
-  const script = `<script src="/sdk.js?key=${encodeURIComponent(key)}"></script>`;
-  if (/<\/body\s*>/i.test(html)) {
-    return html.replace(/<\/body\s*>/i, `${script}</body>`);
+export function classifyLavishSdkFailure({ meaningfulContent, sdkStarted, error }) {
+  if (!meaningfulContent) return null;
+  if (error) return "sdk-crashed";
+  if (sdkStarted) return "sdk-startup-stalled";
+  return "sdk-not-fetched";
+}
+
+function scriptJson(value) {
+  return JSON.stringify(value).replace(/</g, "\\u003c");
+}
+
+export function createLavishHealthBootstrap(key) {
+  return `(() => {
+  const sdkPath=${scriptJson(`/sdk.js?key=${encodeURIComponent(key)}`)};
+  const classifyLavishSdkFailure=${classifyLavishSdkFailure.toString()};
+  const state={ sdkStarted:false, sdkAttached:false, sdkReady:false, sdkError:"", diagnosed:false };
+  let startupTimer=0;
+  let paintTimer=0;
+
+  function post(message) {
+    try { parent.postMessage(message, "*"); } catch {}
   }
-  return `${html}\n${script}`;
+
+  function lifecycle(stage, details={}) {
+    post({ type:"lavish:artifactLifecycle", stage, ...details });
+  }
+
+  function hasMeaningfulContent() {
+    const body=document.body;
+    if (!body) return false;
+    const ignored=new Set(["SCRIPT","STYLE","LINK","META","TITLE","BASE","TEMPLATE","NOSCRIPT"]);
+    const visualTags=new Set(["IMG","PICTURE","SVG","CANVAS","VIDEO","AUDIO","IFRAME","OBJECT","EMBED","INPUT","BUTTON","SELECT","TEXTAREA"]);
+    for (const el of body.querySelectorAll("*")) {
+      if (ignored.has(el.tagName) || el.closest?.("[data-lavish-ui]")) continue;
+      if (el.hidden || el.getAttribute?.("aria-hidden") === "true") continue;
+      let style;
+      try { style=getComputedStyle(el); } catch { continue; }
+      if (style.display === "none" || style.visibility === "hidden" || style.visibility === "collapse" || Number(style.opacity) === 0) continue;
+      let rect;
+      try { rect=el.getBoundingClientRect(); } catch { continue; }
+      if (!rect || rect.width <= 1 || rect.height <= 1) continue;
+      const text=String(el.innerText || "").trim();
+      if (text || visualTags.has(el.tagName)) return true;
+    }
+    return false;
+  }
+
+  function diagnosticCopy(code) {
+    if (code === "sdk-not-fetched") return {
+      title:"Lavish SDK was not fetched",
+      copy:"The browser did not request /sdk.js inside this sandbox. Try Chrome, disable content blocking for localhost, then reload the artifact.",
+    };
+    if (code === "sdk-crashed") return {
+      title:"Lavish SDK crashed during startup",
+      copy:"The SDK began loading but threw before startup completed. Open the artifact frame console, capture the first error, then reload.",
+    };
+    if (code === "sdk-startup-stalled") return {
+      title:"Lavish SDK startup stalled",
+      copy:"The SDK started but window.lavish never attached. Capture the artifact frame console and network log, then reload.",
+    };
+    return {
+      title:"Artifact content was not painted",
+      copy:"The SDK is running and the document has laid-out content, but the browser reported no paint. Preserve this tab, capture a screenshot and console, then reload or open a fresh tab.",
+    };
+  }
+
+  function renderDiagnostic(code, detail) {
+    const existing=document.getElementById("lavish-artifact-diagnostic");
+    if (existing) existing.remove();
+    const host=document.createElement("div");
+    host.id="lavish-artifact-diagnostic";
+    host.setAttribute("data-lavish-ui", "artifact-diagnostic");
+    host.style.cssText="all:initial!important;display:block!important;position:fixed!important;inset:0!important;z-index:2147483647!important;background:#0f1115!important;color:#f7f3ea!important;";
+    const root=host.attachShadow({ mode:"open" });
+    const style=document.createElement("style");
+    style.textContent=":host{color-scheme:dark}.screen{box-sizing:border-box;min-height:100%;display:grid;place-items:center;padding:24px;background:#0f1115;color:#f7f3ea;font:14px/1.45 ui-sans-serif,system-ui,-apple-system,Segoe UI,sans-serif}.card{box-sizing:border-box;width:min(560px,100%);padding:24px;border:1px solid #303745;border-radius:14px;background:#11141a}.eyebrow{margin:0 0 8px;color:#f4c95d;font:700 11px/1.35 ui-monospace,SFMono-Regular,Menlo,monospace;letter-spacing:.08em;text-transform:uppercase}.title{margin:0 0 10px;color:#fffbf3;font:600 22px/1.25 ui-sans-serif,system-ui,-apple-system,Segoe UI,sans-serif}.copy{margin:0;color:#d8deea}.detail{margin:16px 0 0;padding:10px 12px;border:1px solid #303745;border-radius:8px;background:#1c212b;color:#b9c0cf;font:12px/1.45 ui-monospace,SFMono-Regular,Menlo,monospace;overflow-wrap:anywhere}";
+    const screen=document.createElement("div");
+    screen.className="screen";
+    const card=document.createElement("section");
+    card.className="card";
+    card.setAttribute("role", "alert");
+    const eyebrow=document.createElement("p");
+    eyebrow.className="eyebrow";
+    eyebrow.textContent="Artifact diagnostics";
+    const title=document.createElement("h1");
+    title.className="title";
+    const copy=document.createElement("p");
+    copy.className="copy";
+    const content=diagnosticCopy(code);
+    title.textContent=content.title;
+    copy.textContent=content.copy;
+    card.append(eyebrow, title, copy);
+    if (detail) {
+      const detailEl=document.createElement("p");
+      detailEl.className="detail";
+      detailEl.textContent=detail;
+      card.appendChild(detailEl);
+    }
+    screen.appendChild(card);
+    root.append(style, screen);
+    document.documentElement?.appendChild(host);
+  }
+
+  function report(code, detail="", { revealGate=false }={}) {
+    if (state.diagnosed) return;
+    state.diagnosed=true;
+    const content=diagnosticCopy(code);
+    renderDiagnostic(code, detail);
+    lifecycle("failed", { failure:code, detail:String(detail || "").slice(0, 500) });
+    post({
+      type:"lavish:queuePrompt",
+      prompt:{
+        uid:"",
+        prompt:"Lavish diagnostic — " + content.title + ". " + content.copy,
+        selector:"html",
+        tag:"artifact-diagnostic",
+        text:content.title,
+        _lavishQueueKey:"lavish:artifact-health",
+      },
+    });
+    if (revealGate) post({ type:"lavish:layoutWarnings", layout_warnings:[] });
+    try { console.error("[Lavish artifact diagnostic] " + content.title, detail || ""); } catch {}
+  }
+
+  function inspectStartup() {
+    if (state.sdkReady || state.diagnosed) return;
+    const failure=classifyLavishSdkFailure({
+      meaningfulContent:hasMeaningfulContent(),
+      sdkStarted:state.sdkStarted,
+      error:state.sdkError,
+    });
+    if (failure) report(failure, state.sdkError, { revealGate:true });
+    else lifecycle("empty", { sdkReady:false });
+  }
+
+  function inspectPaint() {
+    if (!state.sdkReady || state.diagnosed || !hasMeaningfulContent()) return;
+    if (document.visibilityState === "hidden" || !performance?.getEntriesByType) {
+      lifecycle("paint-unverified");
+      return;
+    }
+    const paints=performance.getEntriesByType("paint").map((entry) => entry.name);
+    if (paints.includes("first-paint") || paints.includes("first-contentful-paint")) {
+      lifecycle("painted", { paints });
+      return;
+    }
+    report("artifact-not-painted", "No first-paint or first-contentful-paint entry was recorded.");
+  }
+
+  const health={
+    markSdkStarted() {
+      state.sdkStarted=true;
+      lifecycle("sdk-started");
+    },
+    markSdkAttached() {
+      state.sdkAttached=true;
+      lifecycle("sdk-attached");
+    },
+    markSdkReady() {
+      if (state.sdkReady) return;
+      state.sdkReady=true;
+      if (startupTimer) clearTimeout(startupTimer);
+      lifecycle("sdk-ready", { meaningfulContent:hasMeaningfulContent() });
+      paintTimer=setTimeout(inspectPaint, 4000);
+      paintTimer?.unref?.();
+    },
+    report,
+  };
+
+  try {
+    Object.defineProperty(window, "__lavishArtifactHealth", { value:health, configurable:true });
+  } catch {
+    window.__lavishArtifactHealth=health;
+  }
+
+  window.addEventListener("error", (event) => {
+    if (state.sdkReady || state.diagnosed) return;
+    const filename=String(event.filename || "");
+    if (!state.sdkStarted && !filename.includes("/sdk.js")) return;
+    state.sdkError=String(event.error?.stack || event.message || "SDK startup error").slice(0, 1200);
+    if (hasMeaningfulContent()) {
+      const attachment=state.sdkAttached ? "window.lavish attached before the crash. " : "window.lavish did not attach. ";
+      report("sdk-crashed", attachment + state.sdkError, { revealGate:true });
+    }
+  });
+  window.addEventListener("unhandledrejection", (event) => {
+    if (!state.sdkStarted || state.sdkReady || state.diagnosed) return;
+    state.sdkError=String(event.reason?.stack || event.reason || "Unhandled SDK rejection").slice(0, 1200);
+    if (hasMeaningfulContent()) {
+      const attachment=state.sdkAttached ? "window.lavish attached before the crash. " : "window.lavish did not attach. ";
+      report("sdk-crashed", attachment + state.sdkError, { revealGate:true });
+    }
+  });
+
+  lifecycle("bootstrap", { sdkPath });
+  startupTimer=setTimeout(inspectStartup, 6000);
+  startupTimer?.unref?.();
+})();`;
+}
+
+export function injectLavishSdk(html, key) {
+  const bootstrap = `<script>${createLavishHealthBootstrap(key)}</script>`;
+  const sdk = `<script data-lavish-sdk src="/sdk.js?key=${encodeURIComponent(key)}"></script>`;
+  const scripts = `${bootstrap}${sdk}`;
+  if (/<\/body\s*>/i.test(html)) {
+    return html.replace(/<\/body\s*>/i, `${scripts}</body>`);
+  }
+  return `${html}\n${scripts}`;
 }

--- a/test/fixtures/artifact-health/empty-sdk-blocked.html
+++ b/test/fixtures/artifact-health/empty-sdk-blocked.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="Content-Security-Policy" content="script-src 'unsafe-inline'" />
+    <title>Empty blocked SDK health fixture</title>
+  </head>
+  <body></body>
+</html>

--- a/test/fixtures/artifact-health/paint-missing.html
+++ b/test/fixtures/artifact-health/paint-missing.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Missing paint health fixture</title>
+    <script>
+      const originalGetEntriesByType = performance.getEntriesByType.bind(performance);
+      performance.getEntriesByType = (type) => (type === "paint" ? [] : originalGetEntriesByType(type));
+    </script>
+  </head>
+  <body>
+    <main><h1>Meaningful artifact content</h1></main>
+  </body>
+</html>

--- a/test/fixtures/artifact-health/sdk-blocked.html
+++ b/test/fixtures/artifact-health/sdk-blocked.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="Content-Security-Policy" content="script-src 'unsafe-inline'" />
+    <title>SDK blocked health fixture</title>
+  </head>
+  <body>
+    <main><h1>Meaningful artifact content</h1></main>
+  </body>
+</html>

--- a/test/fixtures/artifact-health/sdk-crashed.html
+++ b/test/fixtures/artifact-health/sdk-crashed.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>SDK crash health fixture</title>
+    <script>
+      window.MutationObserver = undefined;
+    </script>
+  </head>
+  <body>
+    <main><h1>Meaningful artifact content</h1></main>
+  </body>
+</html>

--- a/test/html-transform.test.js
+++ b/test/html-transform.test.js
@@ -1,13 +1,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { injectLavishSdk } from "../src/html-transform.js";
+import { classifyLavishSdkFailure, createLavishHealthBootstrap, injectLavishSdk } from "../src/html-transform.js";
 
 test("injects the Lavish SDK before the closing body tag", () => {
   const html = "<!doctype html><html><body><h1>Hi</h1></body></html>";
   const result = injectLavishSdk(html, "abc123");
 
-  assert.match(result, /<script src="\/sdk\.js\?key=abc123"><\/script><\/body>/);
+  assert.match(result, /<script data-lavish-sdk src="\/sdk\.js\?key=abc123"><\/script><\/body>/);
+  assert.ok(result.indexOf("__lavishArtifactHealth") < result.indexOf("data-lavish-sdk"));
 });
 
 test("does not inject Tailwind or DaisyUI design assets so the saved file stays portable", () => {
@@ -20,18 +21,48 @@ test("does not inject Tailwind or DaisyUI design assets so the saved file stays 
   assert.doesNotMatch(result, /data-lavish-design/);
 });
 
-test("leaves the <head> untouched - only the SDK script is appended at end of body", () => {
+test("leaves the <head> untouched and appends only the health bootstrap and SDK at end of body", () => {
   const html = "<!doctype html><html><head><title>Hi</title></head><body><h1>Hi</h1></body></html>";
   const result = injectLavishSdk(html, "abc123");
 
-  assert.equal(
-    result,
-    '<!doctype html><html><head><title>Hi</title></head><body><h1>Hi</h1><script src="/sdk.js?key=abc123"></script></body></html>',
-  );
+  assert.match(result, /^<!doctype html><html><head><title>Hi<\/title><\/head><body><h1>Hi<\/h1><script>/);
+  assert.match(result, /<\/script><script data-lavish-sdk src="\/sdk\.js\?key=abc123"><\/script><\/body><\/html>$/);
 });
 
 test("appends the Lavish SDK when the artifact has no body tag", () => {
   const result = injectLavishSdk("<h1>Hi</h1>", "abc123");
 
-  assert.equal(result, '<h1>Hi</h1>\n<script src="/sdk.js?key=abc123"></script>');
+  assert.match(result, /^<h1>Hi<\/h1>\n<script>/);
+  assert.match(result, /<\/script><script data-lavish-sdk src="\/sdk\.js\?key=abc123"><\/script>$/);
+});
+
+test("classifies missing, crashed, and stalled SDK startup without alarming on an empty artifact", () => {
+  assert.equal(classifyLavishSdkFailure({ meaningfulContent: true, sdkStarted: false, error: "" }), "sdk-not-fetched");
+  assert.equal(
+    classifyLavishSdkFailure({
+      meaningfulContent: true,
+      sdkStarted: true,
+      error: "ReferenceError: MutationObserver is not defined",
+    }),
+    "sdk-crashed",
+  );
+  assert.equal(
+    classifyLavishSdkFailure({ meaningfulContent: true, sdkStarted: true, error: "" }),
+    "sdk-startup-stalled",
+  );
+  assert.equal(classifyLavishSdkFailure({ meaningfulContent: false, sdkStarted: false, error: "" }), null);
+});
+
+test("health bootstrap reports specific visible diagnoses over postMessage without opaque-origin storage", () => {
+  const bootstrap = createLavishHealthBootstrap("abc123");
+
+  assert.match(bootstrap, /lavish:artifactLifecycle/);
+  assert.match(bootstrap, /lavish:queuePrompt/);
+  assert.match(bootstrap, /Lavish SDK was not fetched/);
+  assert.match(bootstrap, /Lavish SDK crashed during startup/);
+  assert.match(bootstrap, /Artifact content was not painted/);
+  assert.match(bootstrap, /first-contentful-paint/);
+  assert.match(bootstrap, /data-lavish-ui/);
+  assert.doesNotMatch(bootstrap, /localStorage|sessionStorage/);
+  assert.doesNotThrow(() => new Function(bootstrap));
 });

--- a/test/layout-audit-browser.test.js
+++ b/test/layout-audit-browser.test.js
@@ -10,6 +10,7 @@ import { fileURLToPath } from "node:url";
 const runBrowserE2e = process.env.LAVISH_AXI_BROWSER_E2E === "1";
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const fixtures = path.join(repoRoot, "test/fixtures/layout-audit");
+const healthFixtures = path.join(repoRoot, "test/fixtures/artifact-health");
 
 function run(command, args, env, timeout = 45_000) {
   const result = spawnSync(command, args, {
@@ -65,6 +66,30 @@ test(
       return openArtifact(path.join(fixtures, `${name}.html`));
     }
 
+    function checkArtifactHealth(name, settleMs, expectedDiagnosis = "") {
+      const { url } = openArtifact(path.join(healthFixtures, `${name}.html`));
+      run("chrome-devtools-axi", ["open", url], chromeEnv);
+      run("chrome-devtools-axi", ["wait", String(settleMs)], chromeEnv, settleMs + 45_000);
+      const snapshot = run("chrome-devtools-axi", ["snapshot", "--full"], chromeEnv);
+      const chromeState = run(
+        "chrome-devtools-axi",
+        [
+          "eval",
+          '() => ({ diagnostic: document.body.innerText.includes("Lavish diagnostic"), gate: document.body.classList.contains("layout-gate-active") })',
+        ],
+        chromeEnv,
+      );
+
+      if (expectedDiagnosis) {
+        assert.match(snapshot, new RegExp(expectedDiagnosis), name);
+        assert.match(chromeState, /diagnostic.*true/, name);
+      } else {
+        assert.doesNotMatch(snapshot, /ARTIFACT DIAGNOSTICS|Lavish diagnostic/, name);
+        assert.match(chromeState, /diagnostic.*false/, name);
+      }
+      assert.match(chromeState, /gate.*false/, name);
+    }
+
     function audit(name, viewport, settleMs, expectedCount) {
       const { file, url } = openFixture(name);
       run("chrome-devtools-axi", ["emulate", "--viewport", viewport], chromeEnv);
@@ -100,6 +125,11 @@ test(
     }
 
     try {
+      checkArtifactHealth("sdk-blocked", 7000, "Lavish SDK was not fetched");
+      checkArtifactHealth("sdk-crashed", 1500, "Lavish SDK crashed during startup");
+      checkArtifactHealth("paint-missing", 5000, "Artifact content was not painted");
+      checkArtifactHealth("empty-sdk-blocked", 13_000);
+
       audit("control-broken-occlusion", "1440x1000x1", 3200, 1);
 
       const acceptable = [

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -131,6 +131,16 @@ test("artifact SDK script is valid JavaScript", () => {
   assert.doesNotThrow(() => new Function(js));
 });
 
+test("artifact SDK reports startup and readiness to the injected health watchdog", () => {
+  const js = createSdkJs("abc");
+
+  assert.match(js, /__lavishArtifactHealth\?\.markSdkStarted\?\.\(\)/);
+  assert.match(js, /__lavishArtifactHealth\?\.markSdkAttached\?\.\(\)/);
+  assert.match(js, /__lavishArtifactHealth\?\.markSdkReady\?\.\(\)/);
+  assert.match(js, /type:\s*["']lavish:artifactLifecycle["']/);
+  assert.doesNotMatch(js, /localStorage|sessionStorage/);
+});
+
 test("artifact SDK ignores Lavish-owned annotation UI", () => {
   const js = createSdkJs("abc");
 


### PR DESCRIPTION
## Summary

- inject a small inline artifact-health bootstrap before the external SDK tag
- emit bootstrap, SDK-started, API-attached, SDK-ready, and paint lifecycle messages over postMessage
- show distinct, actionable diagnostics for SDK-not-fetched, SDK-crashed/stalled, and meaningful-content-without-paint cases
- keep legitimately empty artifacts silent
- add opt-in opaque-frame Chromium coverage for every diagnosis and the empty control

## Why

Refs #172.

The issue was also captured intermittently in plain Chrome on a board that had rendered 40 minutes earlier: the artifact document returned 200, but /sdk.js was never requested and the layout-warning POST never occurred. This change does not attempt to fix the underlying browser failure. It makes the next occurrence announce which lifecycle boundary failed.

## Validation

- pnpm run check (593 passed, 1 skipped)
- TMPDIR=$PWD/test LAVISH_AXI_BROWSER_E2E=1 node --test test/layout-audit-browser.test.js (passed)
- real Dogear board in the opaque sandbox: SDK 200, layout-warning POST 200, gate cleared, no diagnostic, no console error
- real-browser failure matrix: visible and distinct SDK-not-fetched, SDK-crashed, and no-paint messages; empty blocked-SDK artifact stayed silent