### PR TITLE
fix: preserve in-progress annotation drafts across reloads + show each comment's target

### DIFF
--- a/src/artifact-sdk.js
+++ b/src/artifact-sdk.js
@@ -1446,7 +1446,7 @@ export function createArtifactSdk(
 
     shadow = host.attachShadow({ mode: "open" });
     const style = document.createElement("style");
-    style.textContent = `:host{all:initial;position:fixed;z-index:2147483647;left:0;top:0;color-scheme:dark;--ink-900:#0f1115;--ink-800:#11141a;--ink-700:#171a21;--ink-600:#1c212b;--steel-700:#2a2f3a;--steel-600:#303745;--steel-500:#3c4557;--steel-400:#8c96aa;--steel-300:#aeb6c6;--steel-200:#b9c0cf;--steel-100:#d8deea;--cream-50:#fffbf3;--cream-100:#f7f3ea;--cream-200:#e8e1cf;--brass-500:#f4c95d;--brass-400:#ffd877;--brass-ink:#17130a;--bg:var(--ink-900);--bg-panel:var(--ink-800);--bg-elevated:var(--ink-600);--fg:var(--cream-100);--fg-faint:var(--steel-300);--border:var(--steel-600);--accent:#f4c95d;--accent-hover:#ffd877;--font-sans:Geist,ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif;--font-mono:"Geist Mono",ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;--radius-md:10px;--radius-xl:14px;--shadow-floating:0 20px 70px rgba(0,0,0,.35);font-family:var(--font-sans)}*{box-sizing:border-box}:focus-visible{outline:2px solid var(--accent);outline-offset:2px}.lavish-text-highlight{position:fixed;pointer-events:none;background:rgba(244,201,93,.28);border-radius:2px;box-shadow:0 0 0 1px rgba(244,201,93,.45)}.lavish-annotation-card{position:fixed;width:min(320px,calc(100vw - 24px));padding:12px;border-radius:var(--radius-xl);background:var(--bg-panel);color:var(--fg);border:1px solid var(--accent);box-shadow:var(--shadow-floating);font:14px/1.4 var(--font-sans)}.lavish-heading{font-weight:700;margin-bottom:6px}.lavish-annotation-card textarea{width:100%;min-height:86px;resize:vertical;border-radius:var(--radius-md);border:1px solid var(--border);background:var(--bg);color:var(--fg);padding:9px;font:inherit;font-family:var(--font-sans)}.lavish-annotation-card textarea::placeholder{color:var(--fg-faint)}.lavish-annotation-card .lavish-hint{margin-top:6px;font-size:11px;color:var(--fg-faint)}.lavish-annotation-card .lavish-row{display:flex;gap:8px;justify-content:flex-end;margin-top:8px}.lavish-annotation-card button{border:0;border-radius:var(--radius-md);padding:8px 10px;font-family:var(--font-sans);font-size:13px;font-weight:700;cursor:pointer}.lavish-annotation-card button:active{opacity:.85}.lavish-annotation-card .lavish-send{background:var(--accent);color:var(--brass-ink)}.lavish-annotation-card .lavish-send:hover{background:var(--accent-hover)}.lavish-annotation-card .lavish-cancel{background:var(--steel-700);color:var(--fg)}`;
+    style.textContent = `:host{all:initial;position:fixed;z-index:2147483647;left:0;top:0;color-scheme:dark;--ink-900:#0f1115;--ink-800:#11141a;--ink-700:#171a21;--ink-600:#1c212b;--steel-700:#2a2f3a;--steel-600:#303745;--steel-500:#3c4557;--steel-400:#8c96aa;--steel-300:#aeb6c6;--steel-200:#b9c0cf;--steel-100:#d8deea;--cream-50:#fffbf3;--cream-100:#f7f3ea;--cream-200:#e8e1cf;--brass-500:#f4c95d;--brass-400:#ffd877;--brass-ink:#17130a;--bg:var(--ink-900);--bg-panel:var(--ink-800);--bg-elevated:var(--ink-600);--fg:var(--cream-100);--fg-faint:var(--steel-300);--border:var(--steel-600);--accent:#f4c95d;--accent-hover:#ffd877;--font-sans:Geist,ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif;--font-mono:"Geist Mono",ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;--radius-md:10px;--radius-xl:14px;--shadow-floating:0 20px 70px rgba(0,0,0,.35);font-family:var(--font-sans)}*{box-sizing:border-box}:focus-visible{outline:2px solid var(--accent);outline-offset:2px}.lavish-text-highlight{position:fixed;pointer-events:none;background:rgba(244,201,93,.28);border-radius:2px;box-shadow:0 0 0 1px rgba(244,201,93,.45)}.lavish-locate-highlight{position:fixed;pointer-events:none;border-radius:6px;background:rgba(244,201,93,.16);box-shadow:0 0 0 2px var(--accent),0 0 0 6px rgba(244,201,93,.28);transition:opacity .12s ease}.lavish-annotation-card{position:fixed;width:min(320px,calc(100vw - 24px));padding:12px;border-radius:var(--radius-xl);background:var(--bg-panel);color:var(--fg);border:1px solid var(--accent);box-shadow:var(--shadow-floating);font:14px/1.4 var(--font-sans)}.lavish-heading{font-weight:700;margin-bottom:6px}.lavish-annotation-card textarea{width:100%;min-height:86px;resize:vertical;border-radius:var(--radius-md);border:1px solid var(--border);background:var(--bg);color:var(--fg);padding:9px;font:inherit;font-family:var(--font-sans)}.lavish-annotation-card textarea::placeholder{color:var(--fg-faint)}.lavish-annotation-card .lavish-hint{margin-top:6px;font-size:11px;color:var(--fg-faint)}.lavish-annotation-card .lavish-row{display:flex;gap:8px;justify-content:flex-end;margin-top:8px}.lavish-annotation-card button{border:0;border-radius:var(--radius-md);padding:8px 10px;font-family:var(--font-sans);font-size:13px;font-weight:700;cursor:pointer}.lavish-annotation-card button:active{opacity:.85}.lavish-annotation-card .lavish-send{background:var(--accent);color:var(--brass-ink)}.lavish-annotation-card .lavish-send:hover{background:var(--accent-hover)}.lavish-annotation-card .lavish-cancel{background:var(--steel-700);color:var(--fg)}`;
     shadow.appendChild(style);
     return shadow;
   }
@@ -1460,6 +1460,145 @@ export function createArtifactSdk(
     hovered = null;
     clearTextHighlight();
     selected = null;
+    // The card is gone, so any half-typed text the chrome was mirroring across
+    // reloads is now stale - clearing it here means a cancelled or queued draft
+    // never resurrects on the next live reload.
+    clearAnnotationDraft();
+  }
+
+  // The annotation card lives in this sandboxed iframe, which is torn down and
+  // recreated on every live reload - so a draft the user is mid-typing must be
+  // mirrored to the chrome (which survives reloads) and replayed afterwards.
+  // We send the readable target context alongside the text so the card can be
+  // reopened anchored to the same element or text range. Only structured-clone-
+  // safe fields travel: the live `element`/`range` on a text-selection context
+  // would throw a DataCloneError, and are recovered from `target` on restore.
+  function serializableContext(annotationContext) {
+    if (!annotationContext || typeof annotationContext !== "object") return null;
+    const clean = {
+      uid: String(annotationContext.uid || ""),
+      selector: String(annotationContext.selector || ""),
+      tag: String(annotationContext.tag || ""),
+      text: String(annotationContext.text || ""),
+    };
+    if (annotationContext.target && typeof annotationContext.target === "object") {
+      try {
+        clean.target = JSON.parse(JSON.stringify(annotationContext.target));
+      } catch {
+        // A non-serializable target just means the card reopens without it.
+      }
+    }
+    return clean;
+  }
+
+  function emitAnnotationDraft(annotationContext, text) {
+    parent.postMessage(
+      {
+        type: "lavish:annotationDraft",
+        draft: { text: String(text || ""), context: serializableContext(annotationContext) },
+      },
+      "*",
+    );
+  }
+
+  function clearAnnotationDraft() {
+    parent.postMessage({ type: "lavish:annotationDraft", draft: null }, "*");
+  }
+
+  function safeQuerySelector(selectorText) {
+    if (!selectorText) return null;
+    try {
+      return document.querySelector(selectorText);
+    } catch {
+      return null;
+    }
+  }
+
+  // Invert nodePath()/rangeBoundary(): walk from the boundary's closest element
+  // down the recorded childNode indices to recover the original text node.
+  function resolveRangeBoundary(boundary) {
+    if (!boundary || typeof boundary !== "object") return null;
+    let node = safeQuerySelector(boundary.selector);
+    if (!node) return null;
+    for (const index of Array.isArray(boundary.path) ? boundary.path : []) {
+      const children = node.childNodes;
+      if (!children || index < 0 || index >= children.length) return null;
+      node = children[index];
+    }
+    return { node, offset: Number(boundary.offset) || 0 };
+  }
+
+  function rebuildTextRange(target) {
+    if (!target || target.type !== "text-range") return null;
+    const start = resolveRangeBoundary(target.start);
+    const end = resolveRangeBoundary(target.end);
+    if (!start || !end) return null;
+    try {
+      const range = document.createRange();
+      range.setStart(start.node, start.offset);
+      range.setEnd(end.node, end.offset);
+      return range.collapsed ? null : range;
+    } catch {
+      return null;
+    }
+  }
+
+  // Reopen the annotation card the reload destroyed, anchored to the same target
+  // and prefilled with the mirrored text. Re-emit so the draft keeps surviving
+  // further reloads until the user queues or cancels it.
+  function restoreAnnotationDraft(draft) {
+    if (!annotationMode || !draft || typeof draft !== "object") return;
+    const text = String(draft.text || "");
+    const annotationContext = draft.context && typeof draft.context === "object" ? draft.context : null;
+    if (!text.trim() || !annotationContext) return;
+
+    const range = rebuildTextRange(annotationContext.target);
+    if (annotationContext.tag === "text" && range) {
+      showAnnotationCard(closestElement(range.commonAncestorContainer), { context: annotationContext, range });
+    } else {
+      const el = safeQuerySelector(annotationContext.selector);
+      if (!el) return;
+      showAnnotationCard(el, { context: annotationContext });
+    }
+
+    const textarea = shadow ? shadow.querySelector(".lavish-annotation-card textarea") : null;
+    if (!textarea) return;
+    textarea.value = text;
+    emitAnnotationDraft(annotationContext, text);
+  }
+
+  // Reveal which element a queued comment targets when its pill is hovered in the
+  // chrome. Drawn as an overlay box over the target's rect (never mutating the
+  // artifact's own styles), scrolling it into view first so off-screen targets
+  // are found. Works for element, text-range, and diagram-node targets alike.
+  function highlightAnnotationTarget(selectorText, target) {
+    clearAnnotationTargetHighlight();
+    const range = rebuildTextRange(target);
+    const el = range ? null : safeQuerySelector(selectorText);
+    const scrollTarget = el || (range ? closestElement(range.commonAncestorContainer) : null);
+    if (!scrollTarget && !range) return;
+    if (scrollTarget && typeof scrollTarget.scrollIntoView === "function") {
+      scrollTarget.scrollIntoView({ block: "center", inline: "nearest" });
+    }
+    const paint = () => {
+      const rect = range ? range.getBoundingClientRect() : el ? el.getBoundingClientRect() : null;
+      if (!rect || (rect.width <= 0 && rect.height <= 0)) return;
+      const root = ensureShadow();
+      const mark = document.createElement("div");
+      mark.className = "lavish-locate-highlight";
+      mark.style.left = rect.left - 3 + "px";
+      mark.style.top = rect.top - 3 + "px";
+      mark.style.width = rect.width + 6 + "px";
+      mark.style.height = rect.height + 6 + "px";
+      root.appendChild(mark);
+    };
+    if (typeof window.requestAnimationFrame === "function") window.requestAnimationFrame(paint);
+    else paint();
+  }
+
+  function clearAnnotationTargetHighlight() {
+    if (!shadow) return;
+    for (const el of [...shadow.querySelectorAll(".lavish-locate-highlight")]) el.remove();
   }
 
   function showAnnotationCard(target, options = {}) {
@@ -1518,6 +1657,9 @@ export function createArtifactSdk(
       if (prompt) queuePrompt(prompt, { ...c, queueKey: "" });
       closeCard();
     };
+    // Mirror the draft to the chrome as the user types, so a live reload that
+    // discards this iframe can replay the in-progress text into a reopened card.
+    textarea.addEventListener("input", () => emitAnnotationDraft(c, textarea.value));
     textarea.addEventListener("keydown", (event) => {
       if (event.key === "Enter" && !event.shiftKey && !event.isComposing) {
         event.preventDefault();
@@ -1548,6 +1690,14 @@ export function createArtifactSdk(
     if (msg.type === "lavish:restoreScroll") {
       window.scrollTo(Number(msg.x) || 0, Number(msg.y) || 0);
     }
+    // A live reload discards this sandboxed iframe (and any open annotation card
+    // with half-typed text). The chrome mirrors the draft across the reload and
+    // replays it here so the card reopens with the text the user was writing.
+    if (msg.type === "lavish:restoreAnnotationDraft") restoreAnnotationDraft(msg.draft);
+    // Hovering a queued pill in the chrome asks us to reveal which element that
+    // comment targets, so the user can see what "aaaaa" was actually about.
+    if (msg.type === "lavish:highlightTarget") highlightAnnotationTarget(msg.selector, msg.target);
+    if (msg.type === "lavish:clearHighlight") clearAnnotationTargetHighlight();
   });
 
   // Capture phase so the mode hotkey fires no matter where focus is inside the artifact -

--- a/src/chrome-client.js
+++ b/src/chrome-client.js
@@ -5,6 +5,7 @@ const sessionData = JSON.parse(sessionDataElement?.textContent || "{}");
 const key = String(sessionData.key || "");
 const filePath = String(sessionData.file || "");
 const queueStorageKey = "lavish-axi:queued:" + key;
+const draftStorageKey = "lavish-axi:draft:" + key;
 const internalQueueKeyField = "_lavishQueueKey";
 const initialChat = Array.isArray(sessionData.initialChat) ? sessionData.initialChat : [];
 const MODE_TOGGLE_HOTKEY_KEY = String(sessionData.modeToggleHotkeyKey || "").toLowerCase();
@@ -60,6 +61,7 @@ const whiteboardError = /** @type {HTMLDivElement} */ (document.getElementById("
 const artifactSrc = frame.dataset.artifactSrc || frame.getAttribute?.("data-artifact-src") || frame.src || "";
 
 const queued = loadQueuedPrompts();
+let annotationDraft = loadAnnotationDraft();
 let annotation = true;
 let ended = false;
 let agentPresence = "waiting";
@@ -122,24 +124,101 @@ function persistQueuedPrompts() {
   }
 }
 
+// The artifact iframe is torn down on every live reload, taking any open
+// annotation card (and its half-typed text) with it. The SDK mirrors that draft
+// up to us via `lavish:annotationDraft`; we persist it here and replay it into a
+// reopened card once the reloaded iframe is ready - so an agent save mid-comment
+// no longer discards what the user was writing.
+function loadAnnotationDraft() {
+  try {
+    const parsed = JSON.parse(sessionStorage.getItem(draftStorageKey) || "null");
+    if (!parsed || typeof parsed !== "object") return null;
+    return typeof parsed.text === "string" && parsed.text.trim() ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function persistAnnotationDraft() {
+  try {
+    if (annotationDraft && typeof annotationDraft.text === "string" && annotationDraft.text.trim()) {
+      sessionStorage.setItem(draftStorageKey, JSON.stringify(annotationDraft));
+    } else {
+      sessionStorage.removeItem(draftStorageKey);
+    }
+  } catch {
+    // The in-memory draft still replays this session if storage is unavailable.
+  }
+}
+
+function setAnnotationDraft(draft) {
+  annotationDraft =
+    draft && typeof draft === "object" && typeof draft.text === "string" && draft.text.trim() ? draft : null;
+  persistAnnotationDraft();
+}
+
+function restoreAnnotationDraftToFrame() {
+  if (!annotationDraft || ended || !annotation) return;
+  postToFrame({ type: "lavish:restoreAnnotationDraft", draft: annotationDraft });
+}
+
+// A human-readable label for what a queued comment targets, so a pill answers
+// "which part of the page was this about?" without hovering. Falls back through
+// the element's own text, then a tag descriptor; freeform messages have neither.
+function promptTargetLabel(prompt) {
+  const text = String(prompt.text || "").trim();
+  if (text && text !== "Freeform message") return text;
+  const tag = String(prompt.tag || "").trim();
+  if (tag === "text") return "selected text";
+  if (tag === "mermaid-node" || tag === "whiteboard") return "diagram";
+  if (tag && tag !== "message" && tag !== "annotation") return "<" + tag + ">";
+  return "";
+}
+
+// A queued comment can be located in the artifact when it carries a CSS selector
+// or a structured target (text range / diagram node); freeform messages cannot.
+function promptIsLocatable(prompt) {
+  return Boolean(prompt && (prompt.selector || (prompt.target && typeof prompt.target === "object")));
+}
+
 function render() {
   annotationPills.innerHTML = queued
-    .map(
-      (prompt, index) =>
-        '<div class="pill-wrap"><div class="pill"><span class="pill-preview">' +
+    .map((prompt, index) => {
+      const targetLabel = promptTargetLabel(prompt);
+      const locatable = promptIsLocatable(prompt);
+      return (
+        '<div class="pill-wrap"' +
+        (locatable ? ' data-locate-index="' + index + '"' : "") +
+        ' tabindex="0"><div class="pill">' +
+        (targetLabel
+          ? '<span class="pill-target"' +
+            (locatable ? "" : ' data-unlocatable="true"') +
+            '><svg class="pill-target-icon" width="11" height="11" viewBox="0 0 12 12" fill="none" aria-hidden="true" focusable="false"><circle cx="6" cy="6" r="4.5" stroke="currentColor" stroke-width="1.3"/><circle cx="6" cy="6" r="1.3" fill="currentColor"/></svg><span class="pill-target-text">' +
+            escapeHtml(targetLabel) +
+            "</span></span>"
+          : "") +
+        '<span class="pill-preview">' +
         escapeHtml(prompt.prompt) +
         '</span><button class="pill-close" type="button" aria-label="Remove queued prompt" data-index="' +
         index +
         '"><svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true" focusable="false"><path d="M1 1L9 9M9 1L1 9" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/></svg></button></div><div class="pill-tooltip">' +
+        (targetLabel
+          ? '<div class="tooltip-label">Targets' +
+            (locatable ? " · hover to locate" : "") +
+            '</div><div class="pill-tooltip-label">' +
+            escapeHtml(targetLabel) +
+            "</div>"
+          : "") +
         (prompt.selector
-          ? '<div class="tooltip-label">Target</div><div class="pill-tooltip-target">' +
+          ? '<div class="tooltip-label">Element</div><div class="pill-tooltip-target">' +
             escapeHtml(prompt.selector) +
             "</div>"
           : "") +
         '<div class="tooltip-label">Prompt</div><div class="pill-tooltip-prompt">' +
         escapeHtml(prompt.prompt) +
-        "</div></div></div>",
-    )
+        "</div></div></div>"
+      );
+    })
     .join("");
 
   for (const button of annotationPills.querySelectorAll(".pill-close")) {
@@ -148,6 +227,53 @@ function render() {
   }
   updateSendState();
   scrollPanelToBottom();
+}
+
+function closestLocatablePill(node) {
+  return node && node.closest ? node.closest("[data-locate-index]") : null;
+}
+
+// Ask the artifact iframe to scroll to and outline the element a queued comment
+// targets. The iframe is sandboxed without same-origin, so the chrome can't
+// touch its DOM directly - it drives the highlight through the SDK's postMessage
+// protocol, the same channel used for annotation mode and scroll restore.
+function locateQueuedPrompt(index) {
+  const prompt = queued[index];
+  if (!prompt || ended) return;
+  postToFrame({ type: "lavish:highlightTarget", selector: prompt.selector || "", target: prompt.target || null });
+}
+
+function clearLocateHighlight() {
+  postToFrame({ type: "lavish:clearHighlight" });
+}
+
+// Delegated on the pills container so a single listener set survives every
+// re-render: hovering or keyboard-focusing a locatable pill reveals its target
+// in the artifact, and leaving it clears the highlight. mouseout is ignored when
+// the pointer merely crosses between a pill's own children (no target change).
+function bindPillLocateHandlers() {
+  annotationPills.addEventListener("mouseover", (event) => {
+    const wrap = closestLocatablePill(event.target);
+    if (wrap) locateQueuedPrompt(Number(wrap.dataset.locateIndex));
+  });
+  annotationPills.addEventListener("mouseout", (event) => {
+    const wrap = closestLocatablePill(event.target);
+    if (!wrap) return;
+    const to = event.relatedTarget;
+    if (to && wrap.contains && wrap.contains(to)) return;
+    clearLocateHighlight();
+  });
+  annotationPills.addEventListener("focusin", (event) => {
+    const wrap = closestLocatablePill(event.target);
+    if (wrap) locateQueuedPrompt(Number(wrap.dataset.locateIndex));
+  });
+  annotationPills.addEventListener("focusout", (event) => {
+    const wrap = closestLocatablePill(event.target);
+    if (!wrap) return;
+    const to = event.relatedTarget;
+    if (to && wrap.contains && wrap.contains(to)) return;
+    clearLocateHighlight();
+  });
 }
 
 function updateSendState() {
@@ -1199,6 +1325,9 @@ window.addEventListener("message", (event) => {
   if (msg.type === "lavish:queuePrompt") {
     enqueuePrompt(msg.prompt);
   }
+  if (msg.type === "lavish:annotationDraft") {
+    setAnnotationDraft(msg.draft);
+  }
   if (msg.type === "lavish:snapshot") {
     const snapshotAction = snapshotRequests.shift() || "submit";
     if (snapshotAction === "copy") {
@@ -1289,6 +1418,8 @@ frame.addEventListener("load", () => {
   postToFrame({ type: "lavish:setAnnotationMode", enabled: annotation && !ended });
   // Replay the pre-reload scroll position so hot reloads don't jump the artifact to the top.
   postToFrame({ type: "lavish:restoreScroll", x: lastScroll.x, y: lastScroll.y });
+  // Reopen a mid-typed annotation card the reload discarded, prefilled with its draft.
+  restoreAnnotationDraftToFrame();
   if (overlayIndex !== null) {
     inlineWhiteboardChannels.delete(overlayIndex);
     postToFrame({ type: "lavish:suspendWhiteboard", diagramIndex: overlayIndex });
@@ -1308,6 +1439,7 @@ events.addEventListener("agent-reply", (event) => addChat("agent", JSON.parse(ev
 events.addEventListener("chat-sync", (event) => syncChat(JSON.parse(event.data).chat || []));
 events.addEventListener("agent-presence", (event) => setAgentPresence(JSON.parse(event.data).state));
 
+bindPillLocateHandlers();
 render();
 initialChat.forEach((item) => addChat(item.role, item.text));
 setAgentPresence("waiting");

--- a/src/chrome.css
+++ b/src/chrome.css
@@ -753,6 +753,12 @@ body.lavish {
   align-items: flex-start;
   width: min(320px, 100%);
   max-width: 100%;
+  outline: none;
+}
+.pill-wrap[data-locate-index]:hover .pill,
+.pill-wrap[data-locate-index]:focus-visible .pill {
+  border-color: var(--accent);
+  cursor: pointer;
 }
 .pill {
   display: flex;
@@ -767,8 +773,35 @@ body.lavish {
   font-size: 12px;
   font-weight: var(--w-bold);
 }
+.pill-target {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex: 0 1 auto;
+  min-width: 0;
+  max-width: 45%;
+  padding: 2px 8px;
+  border-radius: var(--radius-pill);
+  background: var(--bg);
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: var(--w-bold);
+}
+.pill-target[data-unlocatable="true"] {
+  color: var(--fg-label);
+}
+.pill-target-icon {
+  flex: 0 0 auto;
+}
+.pill-target-text {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
 .pill-preview {
   display: block;
+  flex: 1 1 auto;
+  min-width: 0;
   max-width: 220px;
   overflow: hidden;
   white-space: nowrap;
@@ -812,6 +845,11 @@ body.lavish {
   letter-spacing: var(--track-label);
   text-transform: uppercase;
   margin: 0 0 4px;
+}
+.pill-tooltip-label {
+  color: var(--fg);
+  margin-bottom: 8px;
+  overflow-wrap: anywhere;
 }
 .pill-tooltip-target {
   font-family: var(--font-mono);

--- a/test/chrome-client-queue.test.js
+++ b/test/chrome-client-queue.test.js
@@ -274,6 +274,30 @@ async function createChromeHarness({
     queued() {
       return JSON.parse(storage.get("lavish-axi:queued:abc") || "[]");
     },
+    draft() {
+      return JSON.parse(storage.get("lavish-axi:draft:abc") || "null");
+    },
+    fireFrameLoad() {
+      const handler = frame.listeners.get("load");
+      assert.equal(typeof handler, "function", "chrome-client registered a frame load handler");
+      handler();
+    },
+    dispatchPillsEvent(type, options = {}) {
+      const { locateIndex, relatedInside = false } = /** @type {{ locateIndex?: number, relatedInside?: boolean }} */ (
+        options
+      );
+      const handler = element("annotationPills").listeners.get(type);
+      assert.equal(typeof handler, "function", `chrome-client registered a pills ${type} handler`);
+      const wrap =
+        locateIndex === undefined
+          ? null
+          : { dataset: { locateIndex: String(locateIndex) }, contains: (node) => node?.insideWrap === true };
+      const target = { closest: (sel) => (sel === "[data-locate-index]" ? wrap : null) };
+      handler({ target, relatedTarget: relatedInside ? { insideWrap: true } : null });
+    },
+    postedTypes(type) {
+      return postedToFrame.filter((message) => message.type === type);
+    },
     reloadCount() {
       return reloadCount;
     },
@@ -1346,4 +1370,123 @@ test("whiteboard close stays responsive while overlay initialization is pending"
 
   releaseOverlaySources?.();
   await flushPromises();
+});
+
+test("chrome client persists an annotation draft from the artifact and replays it after a reload", async () => {
+  const chrome = await createChromeHarness();
+
+  const context = { uid: "7", selector: "section#free-runner", tag: "section", text: "Free runner idea" };
+  chrome.sendFrameMessage({
+    type: "lavish:annotationDraft",
+    draft: { text: "this needs a caveat", context },
+  });
+
+  assert.deepEqual(chrome.draft(), { text: "this needs a caveat", context });
+
+  // A live reload discards the iframe; on the reloaded frame's load the chrome
+  // must replay the draft so the card reopens with the half-typed text.
+  chrome.fireFrameLoad();
+
+  const replays = chrome.postedTypes("lavish:restoreAnnotationDraft");
+  assert.equal(replays.length, 1);
+  assert.equal(replays[0].draft.text, "this needs a caveat");
+  assert.deepEqual(replays[0].draft.context, context);
+});
+
+test("chrome client clears the persisted draft when the artifact reports it was queued or cancelled", async () => {
+  const chrome = await createChromeHarness();
+
+  chrome.sendFrameMessage({
+    type: "lavish:annotationDraft",
+    draft: { text: "half a thought", context: { selector: "h1", tag: "h1", text: "Title" } },
+  });
+  assert.ok(chrome.draft());
+
+  chrome.sendFrameMessage({ type: "lavish:annotationDraft", draft: null });
+  assert.equal(chrome.draft(), null);
+
+  chrome.fireFrameLoad();
+  assert.equal(chrome.postedTypes("lavish:restoreAnnotationDraft").length, 0);
+});
+
+test("chrome client ignores a blank annotation draft", async () => {
+  const chrome = await createChromeHarness();
+
+  chrome.sendFrameMessage({
+    type: "lavish:annotationDraft",
+    draft: { text: "   ", context: { selector: "h1", tag: "h1", text: "Title" } },
+  });
+
+  assert.equal(chrome.draft(), null);
+  chrome.fireFrameLoad();
+  assert.equal(chrome.postedTypes("lavish:restoreAnnotationDraft").length, 0);
+});
+
+test("chrome client shows each queued comment's readable target on its pill", async () => {
+  const chrome = await createChromeHarness();
+
+  chrome.sendFrameMessage({
+    type: "lavish:queuePrompt",
+    prompt: {
+      prompt: "aaaaa",
+      selector: "section#free-runner",
+      tag: "section",
+      text: "FREE-RUNNER IDEA → RULED OUT",
+    },
+  });
+
+  const html = chrome.element("annotationPills").innerHTML;
+  assert.match(html, /pill-target/);
+  assert.match(html, /FREE-RUNNER IDEA/);
+  assert.match(html, /data-locate-index="0"/);
+});
+
+test("chrome client marks a freeform message pill as unlocatable with no target chip", async () => {
+  const chrome = await createChromeHarness();
+
+  chrome.sendFrameMessage({
+    type: "lavish:queuePrompt",
+    prompt: { uid: "", prompt: "just a note", selector: "", tag: "message", text: "Freeform message" },
+  });
+
+  const html = chrome.element("annotationPills").innerHTML;
+  assert.doesNotMatch(html, /pill-target/);
+  assert.doesNotMatch(html, /data-locate-index/);
+});
+
+test("hovering a locatable pill asks the artifact to highlight its target and leaving clears it", async () => {
+  const chrome = await createChromeHarness();
+
+  chrome.sendFrameMessage({
+    type: "lavish:queuePrompt",
+    prompt: {
+      prompt: "aaaaa",
+      selector: "section#free-runner",
+      tag: "section",
+      text: "Free runner idea",
+      target: { type: "text-range" },
+    },
+  });
+
+  chrome.dispatchPillsEvent("mouseover", { locateIndex: 0 });
+  const highlights = chrome.postedTypes("lavish:highlightTarget");
+  assert.equal(highlights.length, 1);
+  assert.equal(highlights[0].selector, "section#free-runner");
+  assert.deepEqual(highlights[0].target, { type: "text-range" });
+
+  chrome.dispatchPillsEvent("mouseout", { locateIndex: 0 });
+  assert.equal(chrome.postedTypes("lavish:clearHighlight").length, 1);
+});
+
+test("crossing between a pill's own children does not clear the highlight", async () => {
+  const chrome = await createChromeHarness();
+
+  chrome.sendFrameMessage({
+    type: "lavish:queuePrompt",
+    prompt: { prompt: "aaaaa", selector: "h1", tag: "h1", text: "Title" },
+  });
+
+  chrome.dispatchPillsEvent("mouseover", { locateIndex: 0 });
+  chrome.dispatchPillsEvent("mouseout", { locateIndex: 0, relatedInside: true });
+  assert.equal(chrome.postedTypes("lavish:clearHighlight").length, 0);
 });


### PR DESCRIPTION
## What & why

Two annotation-review papercuts in the Lavish Editor chrome, both rooted in the artifact living in a **sandboxed (no `allow-same-origin`) iframe** that is torn down and recreated on every live reload:

### 1. Half-typed annotation text was lost when the artifact re-rendered
An agent saving the artifact mid-comment fires a `reload`; the chrome resets the iframe `src` (`resetFrame`), and the shadow-DOM annotation card — with the text you were writing — is destroyed with no way to recover it. Because the iframe has no `allow-same-origin`, it can't persist anything itself.

**Fix:** the SDK mirrors the draft (text + a structured-clone-safe target context) up to the chrome via a new `lavish:annotationDraft` message on every keystroke. The chrome persists it in `sessionStorage` alongside the queue, and on the reloaded frame's `load` replays `lavish:restoreAnnotationDraft` so the SDK **reopens the card anchored to the same element/text-range, prefilled**. Cleared the moment the draft is queued or cancelled.

### 2. A queued pill didn't say what part of the page a comment was about
The pill showed only the prompt text (e.g. "aaaaa"), with the target buried in a hover tooltip that showed a raw CSS selector.

**Fix:** the already-captured readable target (`context.text`) now renders as a **target chip on the pill**, and hovering / keyboard-focusing a locatable pill **scrolls to and outlines that element in the artifact** (a non-mutating overlay drawn in the SDK's shadow root), driven through the same postMessage protocol as annotation mode. Freeform messages render with no chip and are not locatable.

## Proof it works

**Unit tests** — 7 new cases in `test/chrome-client-queue.test.js` (draft persist/replay/clear, blank-draft ignore, target label, freeform-unlocatable, hover-locate, crossing-children-no-clear). **5 fail red on pristine `main` and pass with the diff** (2 are absence-assertions that hold either way). Full `npm run check` green: build + lint + prettier (my files) + typecheck + `598 tests, 597 pass, 0 fail, 1 skipped` (browser-e2e is env-gated).

**End-to-end in a real browser** (chrome-devtools-axi, driving the built `dist/` server):

| Step | Observed |
|---|---|
| Queue an "aaaaa" comment on the "free-runner idea" card | Pill renders `⊙ FREE-RUNNER ID…  aaaaa` — target chip shows what the comment is about |
| Hover that pill | The free-runner card is scrolled into view and outlined with the accent highlight |
| Type a draft, then **edit the artifact file on disk** (real file-watch reload) | Card **reopens anchored to the same card, prefilled** with "this needs a caveat about the paid runner" |

## Scope
`src/artifact-sdk.js`, `src/chrome-client.js`, `src/chrome.css`, `test/chrome-client-queue.test.js`. No dependency or build changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code) on behalf of @bschussheim-lila.