### PR TITLE
fix: execute every PR body compliance event

### DIFF
--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -1,4 +1,5 @@
 name: Require no-mistakes
+run-name: "PR #${{ github.event.pull_request.number }} body compliance - ${{ github.event.action }} - event ${{ github.run_number }} (run ${{ github.run_id }})"
 
 on:
   pull_request:
@@ -9,8 +10,12 @@ on:
 permissions:
   contents: read
 
+# GitHub concurrency groups retain at most one pending run, replacing older
+# pending runs even when cancel-in-progress is false. Give body-bearing events
+# an immutable per-event group so first-time-fork approvals can never collapse
+# opened/edited checks. Keep synchronize/reopened coalescing as before.
 concurrency:
-  group: no-mistakes-required-${{ github.event.pull_request.number }}
+  group: no-mistakes-required-${{ github.event.pull_request.number }}-${{ (github.event.action == 'opened' || github.event.action == 'edited') && github.run_id || 'head-change' }}
   cancel-in-progress: true
 
 jobs:

--- a/.no-mistakes/evidence/fm/nm-body-events-lavish-axi-r1/pr-body-compliance-replay.md
+++ b/.no-mistakes/evidence/fm/nm-body-events-lavish-axi-r1/pr-body-compliance-replay.md
@@ -1,0 +1,59 @@
+# PR body compliance event replay
+
+Target: `3bd80c71a42d12259071150527a74b03d46019d8`
+
+Base: `966f4d58f769b0ceab5a8baf49982dba0fde4769`
+
+## Verified pre-image and scope
+
+```text
+pre-image: ca417e9ff8453de9768e6737e46c875f1b5669c0
+scope: exact two-hunk rollout; only .github/workflows/no-mistakes-required.yml changed
+```
+
+The replay executed the workflow's actual signature-check shell script for three
+body events on the same PR and head. It also evaluated the target workflow's run
+names and concurrency-group expression with distinct immutable GitHub run IDs.
+
+## Same-head signed, unsigned, signed replay
+
+```text
+PR #558 body compliance - opened - event 41 (run 91001)
+  group=no-mistakes-required-558-91001; signature=signed; check=PASS
+
+PR #558 body compliance - edited - event 42 (run 91002)
+  group=no-mistakes-required-558-91002; signature=unsigned; check=FAIL
+
+PR #558 body compliance - edited - event 43 (run 91003)
+  group=no-mistakes-required-558-91003; signature=signed; check=PASS
+```
+
+Every opened or edited body event received a distinct immutable group, so none
+can replace another pending run. The check deterministically followed the body
+signature state.
+
+## Preserved head-change behavior
+
+```text
+synchronize=no-mistakes-required-558-head-change
+reopened=no-mistakes-required-558-head-change
+cancel-in-progress=true
+```
+
+The replay additionally asserted preservation of the `pull_request` read-only
+boundary, the stable `PR must be raised via no-mistakes` check name, the exact
+signature marker, all three bot exemptions, the four event triggers, and the
+`main` branch filter.
+
+## YAML and live CI status
+
+Ruby's standard YAML parser successfully loaded the target workflow. At local
+validation time, `gh-axi pr list --head fm/nm-body-events-lavish-axi-r1` and
+`gh-axi run list --branch fm/nm-body-events-lavish-axi-r1` both returned zero
+items. Repository CI therefore remains pending until the required PR is opened.
+
+The supplied prior broad-check evidence reported one 30-second real-browser
+timeout followed by an immediate isolated pass in 21 seconds. Because the
+workflow-only diff cannot affect the browser product and the exact failing test
+passed on immediate rerun, this is adjudicated as unrelated test flakiness, not
+a failure of this change.


### PR DESCRIPTION
## Intent

Implement the captain-authorized PR-body compliance-event policy from kunchenguid/no-mistakes PR #558 in lavish-axi. Apply only the exact repository-specific two-hunk rollout to .github/workflows/no-mistakes-required.yml: immutable run-id concurrency groups for every opened or edited body event, preserve synchronize and reopened head-change coalescing and cancel-in-progress, and expose PR number, action, monotonic run number, and immutable run ID in run-name. Preserve the pull_request read-only fork boundary, stable check name, marker, bot exemptions, and all unrelated behavior. Verify the live ca417e9ff pre-image, deterministic signed/unsigned/signed same-head replay, preservation assertions, YAML syntax, and repository CI. The earlier full local check encountered one 30-second real-browser test timeout; its immediate isolated rerun passed in 21 seconds and this evidence should be preserved and adjudicated as flakiness. Ship one PR titled fix: execute every PR body compliance event, stop at CI green, and do not merge.

## What Changed

- Give every opened or edited PR-body event an immutable run-ID concurrency group while preserving head-change coalescing and cancellation behavior.
- Add descriptive workflow run names containing the PR number, action, run number, and run ID.
- Record deterministic replay, preservation, YAML validation, and CI availability evidence for the rollout.

## Risk Assessment

✅ Low: The change exactly matches the authorized two-hunk rollout, uses the verified ca417e9ff pre-image, and preserves the read-only pull_request boundary, stable check name, signature marker, bot exemptions, and head-change coalescing behavior.

## Testing

The supplied broad check had one unrelated 30-second browser timeout followed by an immediate isolated pass in 21 seconds, adjudicated as flakiness. Targeted diff, YAML, preservation, and same-head replay checks passed with committed review evidence; complete acceptance remains pending because no PR or repository CI run exists.

- Evidence: [PR body compliance replay evidence](https://github.com/kunchenguid/lavish-axi/blob/9da19a60236a6b2568c9d32e8c1f366c57fbb57c/.no-mistakes/evidence/fm/nm-body-events-lavish-axi-r1/pr-body-compliance-replay.md)
- Outcome: ⚠️ 1 warning across 1 run (3m1s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ Live repository CI and PR-title evidence cannot be demonstrated because this branch has no pull request or GitHub Actions runs. Open the unmerged PR titled `fix: execute every PR body compliance event` and wait for CI to become green.
- `git diff --unified=80 966f4d58f769b0ceab5a8baf49982dba0fde4769..3bd80c71a42d12259071150527a74b03d46019d8 -- .github/workflows/no-mistakes-required.yml`
- `git ls-tree 966f4d58f769b0ceab5a8baf49982dba0fde4769 .github/workflows/no-mistakes-required.yml`
- `ruby -e 'require "yaml"; p YAML.load_file(".github/workflows/no-mistakes-required.yml").keys'`
- `Inline Node replay executing the workflow signature shell against same-head signed/unsigned/signed bodies and asserting exact scope, run names, concurrency groups, and preserved contracts`
- `Initial inline replay attempt exposed a harness-only interpolation syntax error; the corrected harness completed successfully`
- `gh-axi pr list --head fm/nm-body-events-lavish-axi-r1`
- `gh-axi run list --branch fm/nm-body-events-lavish-axi-r1`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
