### PR TITLE
feat(whiteboard): persist the exported SVG alongside the saved scene

### DIFF
--- a/src/chrome-client.js
+++ b/src/chrome-client.js
@@ -950,6 +950,7 @@ async function persistWhiteboardScene(index, message) {
       source_hash: String(message.sourceHash || ""),
       text_metrics_version: Number(message.textMetricsVersion) || 0,
       scene: message.scene || null,
+      svg: String(message.svg || ""),
       baseline: message.baseline || null,
     }),
   });

--- a/src/server.js
+++ b/src/server.js
@@ -706,6 +706,7 @@ export async function serve({
         sourceHash: String(body.source_hash || body.sourceHash || ""),
         textMetricsVersion: Number(body.text_metrics_version || body.textMetricsVersion) || 0,
         scene: body.scene ?? null,
+        svg: body.svg ?? "",
         baseline: body.baseline ?? null,
       });
       res.json({ status: "saved" });

--- a/src/whiteboard-core.js
+++ b/src/whiteboard-core.js
@@ -105,11 +105,12 @@ export function repairSavedSceneTextMetrics(elements, { measure }) {
   return { elements: repairedElements, repaired };
 }
 
-export function createWhiteboardPersistencePayload(state, scene) {
+export function createWhiteboardPersistencePayload(state, scene, svg = "") {
   return {
     sourceHash: String(state?.sceneSourceHash || ""),
     textMetricsVersion: Math.max(0, Math.floor(Number(state?.textMetricsVersion) || 0)),
     scene: scene ?? null,
+    svg: String(svg || ""),
     baseline: { elements: Array.isArray(state?.baselineElements) ? state.baselineElements : [] },
   };
 }

--- a/src/whiteboard-frame.js
+++ b/src/whiteboard-frame.js
@@ -21,6 +21,7 @@ import {
   Excalidraw,
   exportToBlob,
   exportToCanvas,
+  exportToSvg,
   FONT_FAMILY,
   restore,
 } from "@excalidraw/excalidraw";
@@ -219,13 +220,35 @@ function currentScene() {
   };
 }
 
-function postSave(flushId = "") {
+/** Serialise the current scene as a standalone SVG.
+ *
+ * exportToSvg inlines the fonts it uses as data: URIs, so the result renders
+ * identically with no network access. Returns "" when the export fails: a save
+ * must never be lost because a snapshot could not be produced.
+ */
+async function currentSceneSvg(scene) {
+  if (!scene) return "";
+  try {
+    const svg = await exportToSvg({
+      elements: scene.elements,
+      appState: { ...scene.appState, exportBackground: true },
+      files: scene.files || {},
+    });
+    return svg.outerHTML;
+  } catch (error) {
+    console.warn("could not export scene SVG", describeError(error));
+    return "";
+  }
+}
+
+async function postSave(flushId = "") {
   const scene = currentScene();
   if (!scene) return false;
+  const svg = await currentSceneSvg(scene);
   post({
     type: "lavish-whiteboard:save",
     diagramIndex: state.diagramIndex,
-    ...createWhiteboardPersistencePayload(state, scene),
+    ...createWhiteboardPersistencePayload(state, scene, svg),
     ...(flushId ? { flushId } : {}),
   });
   return true;
@@ -235,28 +258,28 @@ function scheduleSave() {
   if (state.teardownFlushId) return;
   window.clearTimeout(state.saveTimer);
   state.saveTimer = window.setTimeout(() => {
-    postSave();
+    void postSave();
   }, SAVE_DEBOUNCE_MS);
 }
 
-function prepareTeardown(message) {
+async function prepareTeardown(message) {
   const flushId = String(message.flushId || "");
   if (!flushId) return;
   state.teardownFlushId = flushId;
   window.clearTimeout(state.saveTimer);
   state.setLocked?.(true);
-  if (!postSave(flushId)) {
+  if (!(await postSave(flushId))) {
     state.teardownFlushId = "";
     post({ type: "lavish-whiteboard:teardownReady", flushId });
   }
 }
 
-function flushSaveNow(message) {
+async function flushSaveNow(message) {
   const flushId = String(message.flushId || "");
   if (!flushId || state.flushIds.has(flushId)) return;
   state.flushIds.add(flushId);
   window.clearTimeout(state.saveTimer);
-  if (!postSave(flushId)) {
+  if (!(await postSave(flushId))) {
     state.flushIds.delete(flushId);
     post({ type: "lavish-whiteboard:flushComplete", flushId, ok: true });
   }

--- a/src/whiteboard-store.js
+++ b/src/whiteboard-store.js
@@ -78,7 +78,7 @@ export async function saveWhiteboard(
   stateDir,
   key,
   index,
-  { sourceHash, textMetricsVersion = 0, scene, baseline = null },
+  { sourceHash, textMetricsVersion = 0, scene, svg = "", baseline = null },
 ) {
   assertValidRef(key, index);
   const record = {
@@ -86,6 +86,10 @@ export async function saveWhiteboard(
     text_metrics_version: Math.max(0, Math.floor(Number(textMetricsVersion) || 0)),
     updated_at: new Date().toISOString(),
     scene: sanitizeWhiteboardScene(scene),
+    // The SVG exported alongside the scene, with its fonts inlined. Consumers
+    // that publish or archive the diagram need the appearance the author
+    // approved, not a re-render whose fonts may resolve differently.
+    svg: String(svg || ""),
     baseline: baseline ?? null,
   };
   return queueWhiteboardWrite(stateDir, key, index, async () => {
@@ -106,6 +110,7 @@ export async function loadWhiteboard(stateDir, key, index) {
       text_metrics_version: Math.max(0, Math.floor(Number(parsed.text_metrics_version) || 0)),
       updated_at: String(parsed.updated_at || ""),
       scene: parsed.scene ?? null,
+      svg: String(parsed.svg || ""),
       baseline: parsed.baseline ?? null,
     };
   } catch (error) {

--- a/test/whiteboard-core.test.js
+++ b/test/whiteboard-core.test.js
@@ -108,9 +108,20 @@ test("whiteboard persistence payload keeps migration and baseline fields togethe
       sourceHash: "hash-1",
       textMetricsVersion: 1,
       scene,
+      svg: "",
       baseline: { elements: baselineElements },
     },
   );
+});
+
+test("whiteboard persistence payload carries the exported snapshot when one is captured", () => {
+  const scene = { elements: [rect("edited")] };
+  const svg = '<svg xmlns="http://www.w3.org/2000/svg"><text>edited</text></svg>';
+  assert.equal(createWhiteboardPersistencePayload({ sceneSourceHash: "hash-1" }, scene, svg).svg, svg);
+  // A missing or non-string snapshot degrades to empty rather than throwing: a
+  // save must never be lost because the export failed.
+  assert.equal(createWhiteboardPersistencePayload({ sceneSourceHash: "hash-1" }, scene, null).svg, "");
+  assert.equal(createWhiteboardPersistencePayload({ sceneSourceHash: "hash-1" }, scene).svg, "");
 });
 
 // ---------------------------------------------------------------------------

--- a/test/whiteboard-store.test.js
+++ b/test/whiteboard-store.test.js
@@ -36,16 +36,25 @@ test("saveWhiteboard/loadWhiteboard strips persisted theme and canvas background
       files: {},
     };
     const baseline = { elements: [{ id: "A", type: "rectangle" }] };
-    await saveWhiteboard(dir, KEY, 0, { sourceHash: "hash-1", textMetricsVersion: 1, scene, baseline });
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg"><text>A</text></svg>';
+    await saveWhiteboard(dir, KEY, 0, { sourceHash: "hash-1", textMetricsVersion: 1, scene, svg, baseline });
     const loaded = await loadWhiteboard(dir, KEY, 0);
     assert.equal(loaded.source_hash, "hash-1");
     assert.equal(loaded.text_metrics_version, 1);
+    assert.equal(loaded.svg, svg);
     assert.deepEqual(loaded.scene, {
       ...scene,
       appState: { scrollX: 12 },
     });
     assert.deepEqual(loaded.baseline, baseline);
     assert.ok(loaded.updated_at);
+  });
+});
+
+test("saveWhiteboard defaults a missing snapshot to empty", async () => {
+  await withTempDir(async (dir) => {
+    await saveWhiteboard(dir, KEY, 0, { sourceHash: "h", scene: { elements: [] }, baseline: null });
+    assert.equal((await loadWhiteboard(dir, KEY, 0)).svg, "");
   });
 });
 


### PR DESCRIPTION
## Problem

A whiteboard save records the scene but not its appearance. Anything that later publishes, exports, or archives the diagram has to re-render it, and a re-render resolves fonts in whatever environment it runs in — which can differ from the editor the author was looking at. The diagram silently changes face between what was approved and what is displayed.

Excalidraw's own `exportToSvg` already solves this: since 0.18 it inlines the fonts an export uses as `data:` URIs, so the exported SVG renders identically anywhere with no network access. It just is not captured at save time.

## Change

`postSave` calls `exportToSvg` and carries the serialised result on the save payload as `svg`, threaded through:

- `createWhiteboardPersistencePayload` (`whiteboard-core.js`) — new optional third argument, defaults to `""`
- the browser client relay (`chrome-client.js`)
- `PUT /api/:key/whiteboard/:index` (`server.js`)
- `saveWhiteboard` / `loadWhiteboard` (`whiteboard-store.js`)

## Design notes

**Export failure is never fatal.** `currentSceneSvg` catches, warns, and yields `""`; a missing or non-string snapshot stores as `""`. A save must not be lost because a snapshot could not be produced. Consumers that need one can treat empty as absent.

**`postSave` becomes async.** The two flush paths that branch on its boolean return (`prepareTeardown`, `flushSaveNow`) now await it; the debounced timer path fires and forgets with `void`. Behaviour is otherwise unchanged.

**Backward compatible.** The field is additive and defaults to empty, so existing stored records load unchanged and any client that does not send `svg` behaves exactly as before.

## Validation

- `npm run lint` clean
- `npm run typecheck` clean
- `node --test` — 607 passing, 0 failing
- `npm run format:check` — one pre-existing warning on `test/fixtures/layout-audit/real-editorial.html`, untouched by this change

Tests added: the persistence payload carries a captured snapshot and degrades to empty for missing/non-string input; `saveWhiteboard`/`loadWhiteboard` round-trip the field and default it to empty.

## Motivation

Downstream we publish approved artifacts containing these diagrams and need the bytes to render standalone — the approver must see exactly what readers see. Happy to adjust the field name or shape if you'd prefer something different.