### PR TITLE
fix(cli): make version checks near-instant

### DIFF
--- a/.no-mistakes/evidence/fm/lavish-version-fastpath-v1/version-fastpath-e2e.txt
+++ b/.no-mistakes/evidence/fm/lavish-version-fastpath-v1/version-fastpath-e2e.txt
@@ -1,0 +1,24 @@
+Lavish CLI version fast-path end-to-end evidence
+Captured from the built dist/cli.mjs at target commit 48a563e8a2752ec2087cb06d6f3705f534c74c15.
+
+Setup: built dist/cli.mjs with telemetry enabled against a local HTTP server that
+accepts telemetry requests but never responds. Each invocation used a fresh,
+nonexistent LAVISH_AXI_STATE_DIR.
+
+--version: stdout="0.1.45", exit=0, elapsed=65.1ms
+-v: stdout="0.1.45", exit=0, elapsed=64.7ms
+-V: stdout="0.1.45", exit=0, elapsed=66.0ms
+version outputs byte-identical: yes ("0.1.45\n")
+telemetry requests after version probes: 0
+state directory after version probes: NOT CREATED
+
+Compatibility check:
+--version extra: exit=2
+stdout="error: Flags must come after the command\ncode: VALIDATION_ERROR\nhelp[2]: \"Run `cli.mjs <command> [args] [flags]`\",Move `--version` after the command instead of before it"
+
+Positive control after the invalid non-version-only invocation:
+telemetry requests: 2
+state directory: CREATED
+
+Result: the published-form bundle keeps the exact version output and existing AXI
+validation shape while returning in about 65ms and bypassing both heavy side effects.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,6 +158,7 @@ No need to explicitly document the telemetry behaviors.
 
 ## Things to know when editing
 
+- `run()` short-circuits `--version`/`-v`/`-V` (`isVersionOnlyArgv`) before `ensureStateDir` and `initDefaultTelemetry`, because agent harnesses probe every tool's version at session start and the telemetry drain in the `finally` block costs up to a full second. Any new startup work must go after that short-circuit; `test/cli-version.test.js` guards both the latency budget and the "no telemetry request, no state dir" property.
 - `canonicalFile` runs `realpath`, so symlinks resolve to their target before becoming session keys. Two paths that refer to the same file always collapse to one session.
 - The SDK injected into artifacts lives in `src/artifact-sdk.js` and is wrapped by `createSdkJs`.
   It executes inside an iframe sandboxed with `allow-scripts allow-forms allow-popups allow-downloads` (no `allow-same-origin`), so it cannot read the chrome's DOM - communication is `postMessage` only - and it runs the layout audit in the iframe because the chrome cannot directly inspect the sandboxed document.

--- a/src/cli.js
+++ b/src/cli.js
@@ -59,7 +59,20 @@ export function pollExecutionGuidance({ agent = "generic" } = {}) {
   return `${sharedGuidance}${agentGuidance}`;
 }
 
+// Mirrors the SDK's own version-flag detection so the fast path below prints exactly
+// what `runAxiCli` would have printed, for exactly the same argv shapes.
+export function isVersionOnlyArgv(argv) {
+  return argv.length === 1 && (argv[0] === "--version" || argv[0] === "-v" || argv[0] === "-V");
+}
+
 export async function run(argv) {
+  // `--version` sits on the agent-startup hot path (harnesses probe every tool's version
+  // at session start), so it must never pay for state-dir creation or the telemetry
+  // request drain in the `finally` below - that drain alone costs up to a full second.
+  if (isVersionOnlyArgv(argv)) {
+    process.stdout.write(`${VERSION}\n`);
+    return;
+  }
   await ensureStateDir();
   const normalizedArgv = normalizeArgv(argv);
   const agent = detectInvokingAgent(process.env);

--- a/test/cli-version.test.js
+++ b/test/cli-version.test.js
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { createServer } from "node:http";
+import { existsSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { isVersionOnlyArgv, VERSION } from "../src/cli.js";
+
+const execFileAsync = promisify(execFile);
+const BIN = fileURLToPath(new URL("../bin/lavish-axi.js", import.meta.url));
+
+// A regression to the pre-fast-path behavior costs the full telemetry drain (up to
+// 1000ms) plus process startup. This budget sits far below that and far above the
+// ~60ms the fast path actually needs, so it catches the regression without flaking.
+const VERSION_BUDGET_MS = 500;
+
+// Accepts the telemetry connection and never answers, so a regression pays the whole
+// drain timeout instead of a fast connection refusal.
+async function startBlackHoleTelemetry() {
+  const sockets = new Set();
+  const requests = [];
+  const server = createServer((req) => {
+    requests.push(req.url);
+  });
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+  });
+  await new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve(undefined));
+  });
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  return {
+    requests,
+    host: `http://127.0.0.1:${port}`,
+    async close() {
+      for (const socket of sockets) socket.destroy();
+      await new Promise((resolve) => server.close(resolve));
+    },
+  };
+}
+
+test("isVersionOnlyArgv matches exactly the SDK's version-flag shapes", () => {
+  for (const flag of ["--version", "-v", "-V"]) {
+    assert.equal(isVersionOnlyArgv([flag]), true);
+  }
+  for (const argv of [[], ["--help"], ["open"], ["--version", "extra"], ["open", "--version"]]) {
+    assert.equal(isVersionOnlyArgv(argv), false);
+  }
+});
+
+test("--version prints the version fast and skips telemetry and state-dir init", async (t) => {
+  const telemetry = await startBlackHoleTelemetry();
+  const stateParent = await mkdtemp(path.join(tmpdir(), "lavish-version-"));
+  const stateDir = path.join(stateParent, "state");
+  t.after(async () => {
+    await telemetry.close();
+    await rm(stateParent, { recursive: true, force: true });
+  });
+
+  const env = {
+    ...process.env,
+    LAVISH_AXI_STATE_DIR: stateDir,
+    LAVISH_AXI_TELEMETRY: "1",
+    LAVISH_AXI_UMAMI_WEBSITE_ID: "version-fast-path-test",
+    LAVISH_AXI_UMAMI_HOST: telemetry.host,
+  };
+
+  for (const flag of ["--version", "-v", "-V"]) {
+    const startedAt = process.hrtime.bigint();
+    const { stdout } = await execFileAsync(process.execPath, [BIN, flag], { env });
+    const elapsedMs = Number(process.hrtime.bigint() - startedAt) / 1e6;
+
+    assert.equal(stdout, `${VERSION}\n`);
+    assert.ok(
+      elapsedMs < VERSION_BUDGET_MS,
+      `\`${flag}\` took ${Math.round(elapsedMs)}ms, over the ${VERSION_BUDGET_MS}ms budget`,
+    );
+  }
+
+  // The heavy init is provably skipped: no telemetry request was ever sent, and the
+  // state directory was never created.
+  assert.deepEqual(telemetry.requests, []);
+  assert.equal(existsSync(stateDir), false);
+});
+
+test("a non-version invocation still runs the telemetry init the fast path skips", async (t) => {
+  const telemetry = await startBlackHoleTelemetry();
+  const stateParent = await mkdtemp(path.join(tmpdir(), "lavish-version-control-"));
+  const stateDir = path.join(stateParent, "state");
+  t.after(async () => {
+    await telemetry.close();
+    await rm(stateParent, { recursive: true, force: true });
+  });
+
+  await execFileAsync(process.execPath, [BIN, "design"], {
+    env: {
+      ...process.env,
+      LAVISH_AXI_STATE_DIR: stateDir,
+      LAVISH_AXI_TELEMETRY: "1",
+      LAVISH_AXI_UMAMI_WEBSITE_ID: "version-fast-path-test",
+      LAVISH_AXI_UMAMI_HOST: telemetry.host,
+    },
+  });
+
+  assert.ok(telemetry.requests.length > 0, "expected the control command to send telemetry");
+  assert.equal(existsSync(stateDir), true);
+});


### PR DESCRIPTION
## Intent

lavish-axi's `--version` is slow (~1.1s measured), absurd for a version check and directly on the agent startup hot path: firstmate calls `<tool> --version` at every session start. Make `lavish-axi --version` near-instant by skipping heavy startup work on the version path.

Required order of work:
1. Reproduce and time first. Build/run the CLI in this worktree and measure current `lavish-axi --version` wall time so there is a real before-number. The fix must be validated against a measured baseline.
2. Root-cause the slowness. Likely heavy work before the version string prints: full dependency/module loading, telemetry or network calls, config init, browser/daemon/server setup. Confirm what actually executes on the `--version` path.
3. Fix at the root. Add a fast-path so `--version` (and `-v`/`-V` if accepted) prints the version and exits WITHOUT triggering heavy init. Short-circuit as early as possible in the entry point rather than merely deferring one piece. Keep it AXI-ergonomic and consistent with how the CLI already reports its version.
4. Do NOT change the output. The printed version string/format must stay identical; only make it fast.
5. Add a fast regression test (colocated per repo convention) asserting BOTH: (a) `--version` completes well under a strict, non-flaky time budget that clearly catches a regression back to full-init timing, and (b) the heavy init does NOT run on the version path (no network/telemetry/daemon side effect). Turn 'slow because of heavy init' into a guard, not just a timer.
6. Verify and record. Re-time after the fix and put before/after numbers in the PR description.

Acceptance criteria: same version string as before, near-instant; heavy startup init provably skipped on the version path; a colocated fast regression test guards both speed and the no-heavy-init property; AXI ergonomics preserved (the `axi` skill/standards for agent-facing CLI behavior).

Constraints and scope: root-cause fix, not a superficial patch. If the root is a shared library/SDK startup, STILL land a lavish-axi-level fast-path here - a deeper shared-SDK fix is being audited separately, so do NOT expand into other repos. Keep scope to lavish-axi only.

What I found and decided while doing the work (a reviewer reading only the diff would not know this):
- Measured baseline of the globally installed binary: 1.10s / 1.10s / 1.09s wall, but only ~0.12s user CPU. That gap is the tell: the cost was blocking I/O, not computation.
- Root cause is NOT module loading. I measured `import("./src/server.js")` (which pulls in express and the rest) at ~45ms, and a full source run of `bin/lavish-axi.js --version` at ~50-60ms. Module load is not the bottleneck, so I deliberately did NOT restructure imports or add lazy-import machinery - that would have been complexity for no measurable gain.
- The real root cause is in `run()` in src/cli.js: it unconditionally called `ensureStateDir()` and `initDefaultTelemetry()`, fired a pageview plus a `command` track event, and then `await telemetry.close(1_000)` in its `finally` block - draining the in-flight Umami HTTP POST for up to a full second. That drain is the entire ~1s.
- This only reproduces when a Umami website ID is configured, which the published build bakes in at build time (LAVISH_AXI_BUILD_UMAMI_*). That is why the globally installed binary was slow while a fresh local build appeared fast. I reproduced it locally with `LAVISH_AXI_UMAMI_WEBSITE_ID=test` and got exactly 1.09-1.11s, matching the installed binary.
- Fix: an exported `isVersionOnlyArgv(argv)` plus a short-circuit at the very top of `run()`, before `ensureStateDir` and before telemetry init, writing `${VERSION}\n` to stdout. That string is byte-identical to what the AXI SDK's own version branch (`runAxiCli`) would have printed, so output is unchanged.
- I deliberately mirrored the SDK's exact matching shape: only `argv.length === 1` with `--version`, `-v`, or `-V`. This preserves existing behavior for `lavish-axi --version foo`, which still produces the SDK's 'Flags must come after the command' error with exit code 2 (verified).
- Deliberate behavior change worth noting: `--version` no longer emits a telemetry pageview/track event. That is intentional and desirable - it is a per-session harness probe, so counting it was noise, and it is the specific thing that made the command slow.
- I put the fast path in `run()` (one place) rather than duplicating version resolution into `bin/lavish-axi.js`, so it covers both the bundled dist/cli.mjs and source runs without a second copy of the version-resolution logic.
- Regression test is test/cli-version.test.js (colocated per repo convention, node:test). It stands up a black-hole HTTP server that ACCEPTS the telemetry connection and never answers - this is deliberate, because pointing at a closed port would be refused instantly and a regression would not actually pay the 1000ms drain, making the timer test useless. Budget is 500ms: far below the ~1.1s regression and far above the ~60ms the fast path needs.
- The test asserts both properties the task demanded: the latency budget, AND the no-heavy-init guard (zero telemetry requests reached the server, and LAVISH_AXI_STATE_DIR was never created). It also includes a positive control running `design` against the same server, which confirms telemetry DOES fire and the state dir IS created on a normal path - so the guard cannot pass vacuously.
- I verified the test genuinely fails without the fix: with only the fast-path block removed it fails with '`--version` took 1087ms, over the 500ms budget'.
- Timings recorded for the PR body: before 1.10s / 1.10s / 1.09s; after 0.05s / 0.05s / 0.06s (dist bundle, telemetry enabled).
- `pnpm run check` is green: 687 pass, 0 fail, 3 skipped.
- I added one line to AGENTS.md under 'Things to know when editing' recording the invariant that new startup work must go after the version short-circuit, since that is exactly how this regression would be reintroduced. Note CLAUDE.md is a symlink to AGENTS.md in this repo.

## What Changed

- Short-circuit `--version`, `-v`, and `-V` before state-directory and telemetry initialization while preserving the existing version output and argument validation.
- Add regression coverage that enforces a 500 ms budget and verifies version probes create no state directory or telemetry requests, with a normal-command positive control.
- Record end-to-end timings improving from 1.10s / 1.10s / 1.09s to 0.05s / 0.05s / 0.06s.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>
</details>
<details>
<summary>✅ **Rebase** - passed</summary>
</details>
<details>
<summary>✅ **Review** - completed</summary>
</details>
<details>
<summary>✅ **Test** - passed</summary>
</details>
<details>
<summary>✅ **Document** - passed</summary>
</details>
<details>
<summary>✅ **Lint** - passed</summary>
</details>
<details>
<summary>✅ **Push** - passed</summary>
</details>
