### PR TITLE
fix: preserve Mermaid label line breaks

### DIFF
--- a/src/design-reference.js
+++ b/src/design-reference.js
@@ -65,7 +65,7 @@ export const MERMAID_CDN_SNIPPET = `<script type="module">
     return darkQuery.matches;
   }
 
-  const diagrams = [...document.querySelectorAll(".mermaid")].map((el) => ({ el, src: el.textContent }));
+  const diagrams = [...document.querySelectorAll(".mermaid")].map((el) => ({ el, src: el.innerHTML }));
   let applied;
   let rendering = false;
   let queued = false;
@@ -84,7 +84,7 @@ export const MERMAID_CDN_SNIPPET = `<script type="module">
         mermaid.initialize({ startOnLoad: false, theme, securityLevel: "strict" });
         for (const { el, src } of diagrams) {
           el.removeAttribute("data-processed");
-          el.textContent = src;
+          el.innerHTML = src;
         }
         try {
           await mermaid.run({ nodes: diagrams.map((d) => d.el) });

--- a/src/mermaid-source.js
+++ b/src/mermaid-source.js
@@ -43,6 +43,10 @@ function elementHasMermaidClass(node) {
 
 function textContent(node) {
   if (node.nodeName === "#text") return String(node.value || "");
+  // Mermaid treats <br/> inside a quoted label as a meaningful line break.
+  // parse5 represents it as an empty element, so a plain text-content walk
+  // would silently join the text on either side ("OBJECTIVE:do the thing").
+  if (node.tagName === "br") return "<br/>";
   return Array.isArray(node.childNodes) ? node.childNodes.map(textContent).join("") : "";
 }
 

--- a/task-evidence/mermaid-theme/after.html
+++ b/task-evidence/mermaid-theme/after.html
@@ -58,7 +58,7 @@
         return darkQuery.matches;
       }
 
-      const diagrams = [...document.querySelectorAll(".mermaid")].map((el) => ({ el, src: el.textContent }));
+      const diagrams = [...document.querySelectorAll(".mermaid")].map((el) => ({ el, src: el.innerHTML }));
       let applied;
       let rendering = false;
       let queued = false;
@@ -77,7 +77,7 @@
             mermaid.initialize({ startOnLoad: false, theme, securityLevel: "strict" });
             for (const { el, src } of diagrams) {
               el.removeAttribute("data-processed");
-              el.textContent = src;
+              el.innerHTML = src;
             }
             try {
               await mermaid.run({ nodes: diagrams.map((d) => d.el) });

--- a/test/cli-output.test.js
+++ b/test/cli-output.test.js
@@ -498,6 +498,7 @@ test("theme-aware Mermaid snippet serializes rapid theme-change renders", async 
   let nextRenderError;
   let activeRenders = 0;
   let maxActiveRenders = 0;
+  const renderedSources = [];
   let bodyColor = "white";
   let rootColor = "white";
   let rootColorScheme = "normal";
@@ -518,8 +519,20 @@ test("theme-aware Mermaid snippet serializes rapid theme-change renders", async 
       return { data: colors[this.color] };
     },
   };
+  let diagramMarkup = 'flowchart TD\\n  A["OBJECTIVE:<br/>do the thing"]';
   const diagram = {
-    textContent: "flowchart TD\\n  A --> B",
+    get innerHTML() {
+      return diagramMarkup;
+    },
+    set innerHTML(value) {
+      diagramMarkup = value;
+    },
+    get textContent() {
+      return diagramMarkup.replace(/<br\s*\/?\s*>/gi, "");
+    },
+    set textContent(value) {
+      diagramMarkup = value;
+    },
     removeAttribute() {},
   };
   const document = {
@@ -567,6 +580,7 @@ test("theme-aware Mermaid snippet serializes rapid theme-change renders", async 
       initializedThemes.push(theme);
     },
     run() {
+      renderedSources.push(diagram.innerHTML);
       activeRenders += 1;
       maxActiveRenders = Math.max(maxActiveRenders, activeRenders);
       if (nextRenderError) {
@@ -611,6 +625,7 @@ test("theme-aware Mermaid snippet serializes rapid theme-change renders", async 
   assert.equal(typeof transitionListener?.callback, "function");
   assert.equal(transitionListener?.capture, true);
   assert.deepEqual(initializedThemes, ["default"]);
+  assert.deepEqual(renderedSources, ['flowchart TD\\n  A["OBJECTIVE:<br/>do the thing"]']);
   bodyColor = "white-40";
   rootColor = "black";
   transitionListener.callback({ propertyName: "color" });

--- a/test/mermaid-source.test.js
+++ b/test/mermaid-source.test.js
@@ -62,6 +62,16 @@ test("extractMermaidSources strips stray inner markup", () => {
   assert.equal(extractMermaidSources(html)[0].source, "graph TD; A-->B");
 });
 
+test("extractMermaidSources preserves line breaks inside Mermaid labels", () => {
+  const html = `<div class="mermaid">flowchart TD
+  A["OBJECTIVE:<br/>do the thing"]</div>`;
+  assert.equal(
+    extractMermaidSources(html)[0].source,
+    `flowchart TD
+  A["OBJECTIVE:<br/>do the thing"]`,
+  );
+});
+
 test("extractMermaidSources handles single-quoted class attributes and empty input", () => {
   assert.equal(extractMermaidSources(`<div class='mermaid x'>graph TD; A-->B</div>`).length, 1);
   assert.deepEqual(extractMermaidSources(""), []);

--- a/test/server-whiteboard.test.js
+++ b/test/server-whiteboard.test.js
@@ -19,7 +19,7 @@ import { mermaidSourceHash } from "../src/mermaid-source.js";
 const ARTIFACT_HTML = `<!doctype html><html><body>
 <h1>Demo</h1>
 <pre class="mermaid">flowchart TD
-  A[Start] --&gt; B{Ready?}</pre>
+  A["OBJECTIVE:<br/>do the thing"] --&gt; B{Ready?}</pre>
 <pre class="mermaid">sequenceDiagram
   CLI-&gt;&gt;Server: poll</pre>
 </body></html>`;
@@ -107,14 +107,15 @@ test("whiteboard channel tokens are signed, session bound, and short lived", () 
   assert.equal(isValidWhiteboardChannelToken(createWhiteboardChannelToken(secret, "", now), secret, "", now), false);
 });
 
-test("GET /api/:key/mermaid-sources extracts ordered, entity-decoded sources with hashes", async () => {
+test("GET /api/:key/mermaid-sources preserves label breaks and returns ordered sources with hashes", async () => {
   const ctx = await startWhiteboardServer();
   try {
     const data = await fetch(`${ctx.base}/api/${ctx.key}/mermaid-sources`).then((res) => res.json());
     assert.equal(data.sources.length, 2);
     assert.equal(data.sources[0].index, 0);
-    assert.equal(data.sources[0].source, "flowchart TD\n  A[Start] --> B{Ready?}");
-    assert.equal(data.sources[0].hash, mermaidSourceHash("flowchart TD\n  A[Start] --> B{Ready?}"));
+    const expectedFlowchart = 'flowchart TD\n  A["OBJECTIVE:<br/>do the thing"] --> B{Ready?}';
+    assert.equal(data.sources[0].source, expectedFlowchart);
+    assert.equal(data.sources[0].hash, mermaidSourceHash(expectedFlowchart));
     assert.equal(data.sources[1].source, "sequenceDiagram\n  CLI->>Server: poll");
   } finally {
     await ctx.close();


### PR DESCRIPTION
## Intent

Prevent Mermaid and Excalidraw whiteboard labels from silently joining text across authored `<br/>` line breaks, such as rendering `OBJECTIVE:<br/>do the thing` as `OBJECTIVE:do the thing`.

## What Changed

- Preserve Mermaid label markup, including `<br/>` line breaks, when the theme-aware design snippet captures and re-renders diagrams.
- Retain `<br/>` elements when extracting Mermaid source for whiteboards so source text and hashes match the authored diagram.
- Add CLI, source-extraction, and whiteboard server coverage for multiline Mermaid labels.

## Risk Assessment

✅ Low: The change is narrowly scoped and consistently preserves Mermaid <br/> label markup across both browser rerendering and server-side whiteboard source extraction, with no material source risks found.

## Testing

After restoring absent dependencies, targeted browser-snippet, source-extraction, and real server API tests passed; the base implementation reproduced the joined-label bug, while a real Chrome render of the target showed the preserved two-line label, with HTML and screenshot evidence captured.

- Evidence: Chrome-rendered Mermaid label with preserved two-line break (local file: <code>/var/folders/pt/19wwr80d5bs38zmww5rm2vsc0000gn/T/no-mistakes-evidence/01KZSR6BMJW5CK8RS48PP3A335/mermaid-br-label-render.png</code>)
<details>
<summary>Evidence: Repro page using the shipped Mermaid design snippet</summary>

```text
<!doctype html>
<html lang="en" data-theme="luxury">
  <head>
    <meta charset="utf-8" />
    <meta name="viewport" content="width=device-width, initial-scale=1" />
    <title>Mermaid BR label preservation evidence</title>
    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/daisyui@5.5.19/daisyui.css" />
    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/daisyui@5.5.19/themes.css" />
    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4.2.4/dist/index.global.js"></script>

    <!-- FIXED: theme-aware Lavish diagram guidance snippet (verbatim from lavish-axi design). -->
    <script type="module">
      import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11.15.0/dist/mermaid.esm.min.mjs";

      // Render Mermaid in a theme that matches the artifact page, and re-render when
      // the viewer flips the page theme - Mermaid never restyles an already-rendered
      // SVG on its own, so a fixed theme clashes in either light or dark mode.
      const darkQuery = window.matchMedia("(prefers-color-scheme: dark)");

      // Normalize any CSS color the browser produces (rgb, oklch, hsl, named, ...)
      // to [r, g, b, a] bytes via a 1x1 canvas, so parsing never breaks on modern
      // color syntaxes like DaisyUI's oklch() values.
      const paint = document.createElement("canvas").getContext("2d");
      function toRgba(color) {
        paint.clearRect(0, 0, 1, 1);
        paint.fillStyle = "#000";
        paint.fillStyle = color;
        paint.fillRect(0, 0, 1, 1);
        return paint.getImageData(0, 0, 1, 1).data;
      }

      function compositeRgba(foreground, background) {
        const foregroundAlpha = foreground[3] / 255;
        const backgroundAlpha = background[3] / 255;
        const alpha = foregroundAlpha + backgroundAlpha * (1 - foregroundAlpha);
        if (alpha === 0) return [0, 0, 0, 0];
        return [
          (foreground[0] * foregroundAlpha + background[0] * backgroundAlpha * (1 - foregroundAlpha)) / alpha,
          (foreground[1] * foregroundAlpha + background[1] * backgroundAlpha * (1 - foregroundAlpha)) / alpha,
          (foreground[2] * foregroundAlpha + background[2] * backgroundAlpha * (1 - foregroundAlpha)) / alpha,
          alpha * 255,
        ];
      }

      function pageIsDark() {
        // Trust the actually-rendered page background so this works with any theming
        // mechanism: prefers-color-scheme, a data-theme attribute, or plain CSS.
        const root = document.documentElement;
        const rootBackground = toRgba(getComputedStyle(root).backgroundColor);
        const bodyBackground = document.body ? toRgba(getComputedStyle(document.body).backgroundColor) : [0, 0, 0, 0];
        const [r, g, b, a] = compositeRgba(bodyBackground, rootBackground);
        if (a > 0) {
          return (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255 < 0.5;
        }
        const colorScheme = getComputedStyle(root).colorScheme;
        if (colorScheme.includes("dark") && !colorScheme.includes("light")) return true;
        if (colorScheme.includes("light") && !colorScheme.includes("dark")) return false;
        return darkQuery.matches;
      }

      const diagrams = [...document.querySelectorAll(".mermaid")].map((el) => ({ el, src: el.innerHTML }));
      let applied;
      let rendering = false;
      let queued = false;
      function queueRender() {
        queued = true;
        if (rendering) return;
        void render();
      }
      async function render() {
        rendering = true;
        try {
          while (queued) {
            queued = false;
            const theme = pageIsDark() ? "dark" : "default";
            if (theme === applied) continue;
            mermaid.initialize({ startOnLoad: false, theme, securityLevel: "strict" });
            for (const { el, src } of diagrams) {
              el.removeAttribute("data-processed");
              el.innerHTML = src;
            }
            try {
              await mermaid.run({ nodes: diagrams.map((d) => d.el) });
            } catch (error) {
              console.error("Mermaid diagram render failed:", error);
              return;
            }
            applied = theme;
          }
        } finally {
          rendering = false;
          if (queued) queueRender();
        }
      }

      // First render once stylesheets are applied (no wrong-theme flash), then keep
      // the diagrams in sync with page-theme toggles and OS light/dark changes.
      if (document.readyState === "complete") queueRender();
      else window.addEventListener("load", queueRender, { once: true });
      const themeObserver = new MutationObserver(queueRender);
      for (const el of [document.documentElement, document.body]) {
        if (!el) continue;
        themeObserver.observe(el, {
          attributes: true,
          attributeFilter: ["data-theme", "class", "style"],
        });
      }
      document.addEventListener("change", queueRender, true);
      document.addEventListener(
        "transitionend",
        ({ propertyName }) => {
          if (propertyName === "background-color") queueRender();
        },
        true,
      );
      darkQuery.addEventListener("change", queueRender);
    </script>
  </head>
  <body class="min-h-screen bg-base-100 text-base-content">
    <main class="mx-auto max-w-4xl p-6 lg:p-10">
      <header class="mb-8 flex flex-wrap items-center justify-between gap-4">
        <div>
          <h1 class="text-3xl font-bold">Mermaid label line-break preservation</h1>
          <p class="mt-1 text-base-content/70">Rendered through the shipped <code>lavish-axi design</code> Mermaid snippet</p>
        </div>
        <label class="flex cursor-pointer items-center gap-3">
          <span class="text-sm font-medium">Dark</span>
          <input type="checkbox" class="toggle toggle-primary" id="theme-toggle" />
          <span class="text-sm font-medium">Light</span>
        </label>
      </header>

      <section class="card card-border bg-base-200">
        <div class="card-body">
          <h2 class="card-title">Expected: two lines inside the node</h2>
          <pre class="mermaid">
flowchart TD
    A["OBJECTIVE:<br/>do the thing"] --> B["DONE"]
          </pre>
        </div>
      </section>
    </main>

    <script>
      const toggle = document.getElementById("theme-toggle");
      toggle.addEventListener("change", () => {
        document.documentElement.setAttribute("data-theme", toggle.checked ? "light" : "luxury");
      });
    </script>
  </body>
</html>
```
</details>
<details>
<summary>Evidence: Executable baseline reproduction</summary>

```text
Base commit extraction produced `OBJECTIVE:do the thing`, confirming the reported line-break loss before the fix.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"5f3c5ab3bbf5fd6b01901d9bf3f2350caa43b06f","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`pnpm install --frozen-lockfile` to restore missing lockfile-pinned dependencies after the initial test setup failure</code>
- `node --test --test-name-pattern 'theme-aware Mermaid snippet serializes rapid theme-change renders' test/cli-output.test.js`
- `node --test --test-name-pattern 'extractMermaidSources preserves line breaks inside Mermaid labels' test/mermaid-source.test.js`
- `node --test --test-name-pattern 'GET /api/:key/mermaid-sources preserves label breaks' test/server-whiteboard.test.js`
- <code>Executed the base-commit `extractMermaidSources` implementation through Node against `OBJECTIVE:&lt;br/&gt;do the thing`; it reproduced the broken joined label</code>
- `Served the evidence HTML locally and rendered it with headless Google Chrome at 1200×800`
- <code>Visually inspected `mermaid-br-label-render.png` and confirmed the node contains two distinct label lines</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
