### PR TITLE
fix: add performance budgets and preserve Mermaid label breaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,4 @@ jobs:
       - run: pnpm run typecheck
       - run: pnpm test
       - run: pnpm run build
+      - run: pnpm run size:check

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,0 +1,26 @@
+name: Performance evidence
+
+on:
+  workflow_dispatch:
+
+jobs:
+  process-benchmarks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: hyperfine@1.20.0
+          fallback: none
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run bench:process
+      - uses: actions/upload-artifact@v6
+        with:
+          name: lavish-performance-evidence
+          path: .lavish-performance/runs/
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 coverage/
 .lavish/
 .lavish-axi/
+.lavish-performance/
 .DS_Store
 *.log
 package-lock.json

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,0 +1,47 @@
+[
+  {
+    "name": "CLI bundle",
+    "path": "dist/cli.mjs",
+    "limit": "450 kB",
+    "brotli": false
+  },
+  {
+    "name": "Chrome runtime",
+    "path": ["dist/chrome-client.js", "dist/chrome.css"],
+    "limit": "105 kB",
+    "brotli": false
+  },
+  {
+    "name": "Design runtime",
+    "path": "dist/design/**",
+    "limit": "1.35 MB",
+    "brotli": false
+  },
+  {
+    "name": "Whiteboard JavaScript",
+    "path": "dist/whiteboard/whiteboard.js",
+    "limit": "8 MB",
+    "brotli": false
+  },
+  {
+    "name": "Whiteboard styles and fonts",
+    "path": ["dist/whiteboard/**", "!dist/whiteboard/whiteboard.js"],
+    "limit": "720 kB",
+    "brotli": false
+  },
+  {
+    "name": "Published package payload",
+    "path": [
+      "dist/**",
+      "plugin.json",
+      "skills/lavish/**",
+      "lavish-editor-marketing/renders/lavish-editor-marketing.gif",
+      "LICENSE",
+      "THIRD-PARTY-NOTICES.md",
+      "README.md",
+      "package.json"
+    ],
+    "limit": "15.8 MB",
+    "brotli": false
+  }
+]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ This file provides guidance to coding agents when working with code in this repo
 ## Commands
 
 ```sh
-pnpm run check          # Run build, lint, format check, typecheck, tests, and skill freshness check
+pnpm run check          # Run build, size budgets, lint, format check, typecheck, tests, and generated-file checks
 pnpm run build          # Bundle dist/cli.mjs and copy chrome/design assets into dist
 pnpm run build:skill    # Regenerate skills/lavish/SKILL.md from shared CLI guidance
 pnpm test               # node:test runner (test/*.test.js)
@@ -48,6 +48,7 @@ Lavish Editor is a CLI + local HTTP server that opens agent-generated HTML artif
 ### Process model
 
 The CLI (`bin/lavish-axi.js` -> `src/cli.js`) spawns `lavish-axi server` as a **detached** background process (`src/cli.js:startServer`) and waits for `/health`, which returns `{ ok, app, version }`.
+Benchmark servers also return `benchmarkRunId`. The process benchmark uses this ID for bounded readiness, identity-checked shutdown, and exit-receipt cleanup. It refuses to stop a different server.
 Later CLI invocations reuse the running server only when its health version matches the current CLI version; stale servers are asked to `POST /shutdown`, and pre-handshake servers may be SIGTERM'd by port PID before the upgraded server is spawned.
 Host, port, and link-host resolution lives in `src/paths.js` (`bindHost`/`clientHost`/`linkHost`); the CLI's own control-channel requests dial the bind host, falling back to loopback when it is a wildcard.
 A Host-header allowlist middleware (`buildAllowedHostnames`/`isAllowedRequestHost`) rejects any request whose `Host` is missing or not one this server answers to - the DNS-rebinding defense, since `isSameOriginRequest` alone does not stop rebinding (a rebound page sends its hostile domain in _both_ `Origin` and `Host`, so they still match). The allowlist is loopback names + the resolved bind/link host + explicit `LAVISH_AXI_ALLOWED_HOSTS` extras (`src/paths.js:extraAllowedHosts`), minus wildcard binds; a lone `*` (`allowsAllHosts`) disables the guard for operators fronting it with their own auth. When a reverse proxy sits in front, `X-Forwarded-Host`'s outermost value is validated as a complete authority against the same allowlist (an AND check, so a spoofed or malformed forwarded host only narrows access, never bypasses `Host`); the `*` opt-out skips hostname membership but still rejects malformed authorities. README's Allowed hosts bullet owns the user-facing contract. So a specific-interface bind stays rebinding-protected while its own hostname works, rather than the guard switching off outside loopback.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,27 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
 - Do not hand-edit `CHANGELOG.md` or `.release-please-manifest.json`.
 - User-facing telemetry docs should stay minimal: anonymous usage telemetry, no sensitive content, and `LAVISH_AXI_TELEMETRY=0` opt-out.
 
+## Performance evidence
+
+`pnpm run check` builds the package and applies deterministic raw-byte budgets with
+[Size Limit](https://github.com/ai/size-limit). Run `pnpm run size:why` to inspect
+esbuild's input contribution report after a budget failure.
+
+Process benchmarks use [Hyperfine 1.20.0](https://github.com/sharkdp/hyperfine/releases/tag/v1.20.0).
+Install that exact version and make sure that `hyperfine --version` reports `1.20.0`.
+Then run:
+
+```sh
+pnpm run bench:process
+```
+
+The command records separate CLI-startup, cold-server, and warm-session results under
+`.lavish-performance/runs/`. It does not update a baseline or fail on a timing change.
+Use the manual `Performance evidence` GitHub Actions workflow for a Linux reference run.
+
+Do not add repeated timing or browser measurements to `pnpm run check`. Add a browser
+benchmark only after its proposal names a browser-owned readiness boundary and tool.
+
 ## Questions
 
 Open an issue, or talk to me on [Discord](https://discord.gg/Wsy2NpnZDu).

--- a/package.json
+++ b/package.json
@@ -20,13 +20,16 @@
     "build": "node scripts/build.js",
     "build:skill": "node scripts/build-skill.js",
     "build:plugin": "node scripts/build-plugin.js",
-    "check": "npm run build && npm run lint && npm run format:check && npm run typecheck && npm test && node scripts/build-skill.js --check && node scripts/build-plugin.js --check",
+    "check": "npm run build && npm run size:check && npm run lint && npm run format:check && npm run typecheck && npm test && node scripts/build-skill.js --check && node scripts/build-plugin.js --check",
     "start": "node dist/cli.mjs",
     "lint": "eslint bin src test scripts",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "prepack": "npm run build",
     "prepare": "npm run build",
+    "size:check": "size-limit",
+    "size:why": "npm run build && node scripts/performance/analyze-bundles.js",
+    "bench:process": "npm run build && node scripts/performance/run.js",
     "test": "node --test",
     "typecheck": "tsc --noEmit"
   },
@@ -44,6 +47,7 @@
     "@eslint/js": "^10.0.1",
     "@excalidraw/excalidraw": "0.18.1",
     "@excalidraw/mermaid-to-excalidraw": "2.2.2",
+    "@size-limit/file": "13.0.3",
     "@types/node": "^25.6.2",
     "esbuild": "^0.28.0",
     "eslint": "^10.3.0",
@@ -53,6 +57,7 @@
     "prettier": "^3.8.3",
     "react": "18.3.1",
     "react-dom": "18.3.1",
+    "size-limit": "13.0.3",
     "typescript": "^5.9.3"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       "@excalidraw/mermaid-to-excalidraw":
         specifier: 2.2.2
         version: 2.2.2
+      "@size-limit/file":
+        specifier: 13.0.3
+        version: 13.0.3(size-limit@13.0.3)
       "@types/node":
         specifier: ^25.6.2
         version: 25.7.0
@@ -68,6 +71,9 @@ importers:
       react-dom:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
+      size-limit:
+        specifier: 13.0.3
+        version: 13.0.3
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -736,6 +742,13 @@ packages:
     resolution:
       { integrity: sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg== }
 
+  "@size-limit/file@13.0.3":
+    resolution:
+      { integrity: sha512-PWTITIXH5p9aGIf6qq2Fruihn/b9nBQyfkyoAyb6DzFJgS1Ek9MSPJYKxKFLO8jdo0aqSgBPd3sevbS6PyBiJw== }
+    engines: { node: ^20.0.0 || ^22.0.0 || >=24.0.0 }
+    peerDependencies:
+      size-limit: 13.0.3
+
   "@tailwindcss/browser@4.2.4":
     resolution:
       { integrity: sha512-yd+3CxxuF1KDt9Q+405JR3/vyotvS5eMIsZPEynEak/JybvFVn8mVmLjVUxgNmrFB6EGCc89lXBECzIZA+YeXQ== }
@@ -961,6 +974,11 @@ packages:
     resolution:
       { integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q== }
     engines: { node: ">=18" }
+
+  bytes-iec@3.1.1:
+    resolution:
+      { integrity: sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA== }
+    engines: { node: ">= 0.8" }
 
   bytes@3.1.2:
     resolution:
@@ -1722,6 +1740,11 @@ packages:
       { integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ== }
     engines: { node: ">= 0.8.0" }
 
+  lilconfig@3.1.3:
+    resolution:
+      { integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw== }
+    engines: { node: ">=14" }
+
   locate-path@6.0.0:
     resolution:
       { integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw== }
@@ -1807,6 +1830,10 @@ packages:
       { integrity: sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw== }
     engines: { node: ^14 || ^16 || >=18 }
     hasBin: true
+
+  nanospinner@1.2.2:
+    resolution:
+      { integrity: sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA== }
 
   natural-compare@1.4.0:
     resolution:
@@ -1907,6 +1934,10 @@ packages:
   pica@7.1.1:
     resolution:
       { integrity: sha512-WY73tMvNzXWEld2LicT9Y260L43isrZ85tPuqRyvtkljSDLmnNFQmZICt4xUJMVulmcc6L9O7jbBrtx3DOz/YQ== }
+
+  picocolors@1.1.1:
+    resolution:
+      { integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA== }
 
   picomatch@2.3.2:
     resolution:
@@ -2114,6 +2145,12 @@ packages:
     resolution:
       { integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw== }
     engines: { node: ">= 0.4" }
+
+  size-limit@13.0.3:
+    resolution:
+      { integrity: sha512-KVb2aNEU49BwTR21SVjD+2QHP9gBV/nWsTHzNB/heRwXtHyA7lLQiDZDQ1TiNh/B/TZXKAZrHYyTt+cvBUrzYw== }
+    engines: { node: ^22.18.0 || ^24.0.0 || >=26.0.0 }
+    hasBin: true
 
   sliced@1.0.1:
     resolution:
@@ -2773,6 +2810,10 @@ snapshots:
 
   "@radix-ui/rect@1.1.0": {}
 
+  "@size-limit/file@13.0.3(size-limit@13.0.3)":
+    dependencies:
+      size-limit: 13.0.3
+
   "@tailwindcss/browser@4.2.4": {}
 
   "@toon-format/toon@2.1.0": {}
@@ -2971,6 +3012,8 @@ snapshots:
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
+
+  bytes-iec@3.1.1: {}
 
   bytes@3.1.2: {}
 
@@ -3621,6 +3664,8 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  lilconfig@3.1.3: {}
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
@@ -3688,6 +3733,10 @@ snapshots:
   nanoid@3.3.3: {}
 
   nanoid@4.0.2: {}
+
+  nanospinner@1.2.2:
+    dependencies:
+      picocolors: 1.1.1
 
   natural-compare@1.4.0: {}
 
@@ -3760,6 +3809,8 @@ snapshots:
       multimath: 2.0.0
       object-assign: 4.1.1
       webworkify: 1.5.0
+
+  picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
 
@@ -3948,6 +3999,12 @@ snapshots:
       side-channel-list: 1.0.1
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
+
+  size-limit@13.0.3:
+    dependencies:
+      bytes-iec: 3.1.1
+      lilconfig: 3.1.3
+      nanospinner: 1.2.2
 
   sliced@1.0.1: {}
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,18 +1,20 @@
-import { chmod, copyFile, cp, mkdir, readFile } from "node:fs/promises";
+import { chmod, copyFile, cp, mkdir, readFile, writeFile } from "node:fs/promises";
 
 import * as esbuild from "esbuild";
 
 const packageJson = JSON.parse(await readFile(new URL("../package.json", import.meta.url), "utf8"));
 
 await mkdir("dist", { recursive: true });
+await mkdir(".lavish-performance/build", { recursive: true });
 
-await esbuild.build({
+const cliBuild = await esbuild.build({
   entryPoints: ["bin/lavish-axi.js"],
   outfile: "dist/cli.mjs",
   bundle: true,
   packages: "external",
   platform: "node",
   format: "esm",
+  metafile: true,
   target: "node22",
   define: {
     "process.env.LAVISH_AXI_BUILD_UMAMI_HOST": JSON.stringify(process.env.LAVISH_AXI_UMAMI_HOST || ""),
@@ -20,6 +22,7 @@ await esbuild.build({
     "process.env.LAVISH_AXI_BUILD_VERSION": JSON.stringify(packageJson.version),
   },
 });
+await writeFile(".lavish-performance/build/cli-metafile.json", `${JSON.stringify(cliBuild.metafile, null, 2)}\n`);
 
 await chmod("dist/cli.mjs", 0o755);
 await copyFile("src/chrome-client.js", "dist/chrome-client.js");
@@ -35,11 +38,12 @@ await copyFile("node_modules/@tailwindcss/browser/dist/index.global.js", "dist/d
 // in a `.mermaid` container.
 // Everything is vendored so the eagerly loaded whiteboards work fully offline.
 await mkdir("dist/whiteboard", { recursive: true });
-await esbuild.build({
+const whiteboardBuild = await esbuild.build({
   entryPoints: { whiteboard: "src/whiteboard-frame.js" },
   outdir: "dist/whiteboard",
   bundle: true,
   minify: true,
+  metafile: true,
   format: "iife",
   platform: "browser",
   conditions: ["production"],
@@ -49,6 +53,10 @@ await esbuild.build({
     "process.env.IS_PREACT": '"false"',
   },
 });
+await writeFile(
+  ".lavish-performance/build/whiteboard-metafile.json",
+  `${JSON.stringify(whiteboardBuild.metafile, null, 2)}\n`,
+);
 
 // Excalidraw lazily fetches canvas fonts from `EXCALIDRAW_ASSET_PATH/fonts/`.
 // Vendor every family except Xiaolai (12 MB of CJK glyphs; those fall back to

--- a/scripts/performance/analyze-bundles.js
+++ b/scripts/performance/analyze-bundles.js
@@ -1,0 +1,10 @@
+// @ts-check
+import { readFile } from "node:fs/promises";
+
+import * as esbuild from "esbuild";
+
+for (const name of ["cli", "whiteboard"]) {
+  const metafile = JSON.parse(await readFile(`.lavish-performance/build/${name}-metafile.json`, "utf8"));
+  console.log(`\n${name} bundle\n`);
+  console.log(await esbuild.analyzeMetafile(metafile));
+}

--- a/scripts/performance/run.js
+++ b/scripts/performance/run.js
@@ -33,6 +33,7 @@ if (hyperfineVersion !== `hyperfine ${HYPERFINE_VERSION}`) {
 }
 
 const common = smoke ? ["--runs", "2"] : ["--warmup", "3", "--min-runs", "10"];
+let runError;
 try {
   runHyperfine([...common, "--export-json", path.join(outputDir, "cli-version.json"), "node dist/cli.mjs --version"]);
 
@@ -54,9 +55,19 @@ try {
     path.join(outputDir, "warm-session.json"),
     "node scripts/performance/scenario.js warm-session",
   ]);
-} finally {
-  runScenario("stop-server", false);
+} catch (error) {
+  runError = error;
 }
+
+try {
+  runScenario("stop-server");
+} catch (cleanupError) {
+  if (!runError) throw cleanupError;
+  if (runError instanceof Error) {
+    runError.message = `${runError.message}; cleanup also failed: ${errorMessage(cleanupError)}`;
+  }
+}
+if (runError) throw runError;
 
 const metadata = {
   schemaVersion: 1,
@@ -79,14 +90,18 @@ function runHyperfine(args) {
   if (result.status !== 0) throw new Error(`hyperfine exited with status ${String(result.status)}`);
 }
 
-function runScenario(command, required = true) {
+function runScenario(command) {
   const result = spawnSync(process.execPath, ["scripts/performance/scenario.js", command], {
     cwd: root,
     env,
     encoding: "utf8",
   });
-  if (result.error && required) throw result.error;
-  if (result.status !== 0 && required) throw new Error(result.stderr.trim() || `${command} failed`);
+  if (result.error) throw result.error;
+  if (result.status !== 0) throw new Error(result.stderr.trim() || `${command} failed`);
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function commandOutput(command, args) {

--- a/scripts/performance/run.js
+++ b/scripts/performance/run.js
@@ -1,0 +1,108 @@
+// @ts-check
+import { spawnSync } from "node:child_process";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+
+const HYPERFINE_VERSION = "1.20.0";
+const smoke = process.argv.includes("--smoke");
+const root = path.resolve(import.meta.dirname, "../..");
+const outputRoot = path.resolve(process.env.LAVISH_AXI_BENCH_OUTPUT_DIR || ".lavish-performance/runs");
+const runName = new Date().toISOString().replaceAll(":", "-");
+const outputDir = path.join(outputRoot, runName);
+const runtimeDir = path.join(outputDir, "runtime");
+const stateDir = await mkdtemp(path.join(os.tmpdir(), "lavish-performance-"));
+const fixture = path.join(root, "test/fixtures/performance/minimal.html");
+const port = await unusedPort();
+const sessionIterations = smoke ? 3 : 25;
+const env = {
+  ...process.env,
+  LAVISH_AXI_BENCH_FIXTURE: fixture,
+  LAVISH_AXI_BENCH_PORT: String(port),
+  LAVISH_AXI_BENCH_RUNTIME_DIR: runtimeDir,
+  LAVISH_AXI_BENCH_SESSION_ITERATIONS: String(sessionIterations),
+  LAVISH_AXI_BENCH_STATE_DIR: stateDir,
+};
+
+await mkdir(outputDir, { recursive: true });
+const hyperfineVersion = commandOutput("hyperfine", ["--version"]);
+if (hyperfineVersion !== `hyperfine ${HYPERFINE_VERSION}`) {
+  throw new Error(`bench:process requires hyperfine ${HYPERFINE_VERSION}; found ${hyperfineVersion || "nothing"}`);
+}
+
+const common = smoke ? ["--runs", "2"] : ["--warmup", "3", "--min-runs", "10"];
+try {
+  runHyperfine([...common, "--export-json", path.join(outputDir, "cli-version.json"), "node dist/cli.mjs --version"]);
+
+  runHyperfine([
+    ...common,
+    "--prepare",
+    "node scripts/performance/scenario.js stop-server",
+    "--cleanup",
+    "node scripts/performance/scenario.js stop-server",
+    "--export-json",
+    path.join(outputDir, "cold-server.json"),
+    "node scripts/performance/scenario.js start-server",
+  ]);
+
+  runScenario("start-server");
+  runHyperfine([
+    ...common,
+    "--export-json",
+    path.join(outputDir, "warm-session.json"),
+    "node scripts/performance/scenario.js warm-session",
+  ]);
+} finally {
+  runScenario("stop-server", false);
+}
+
+const metadata = {
+  schemaVersion: 1,
+  commit: commandOutput("git", ["rev-parse", "HEAD"]),
+  recordedAt: new Date().toISOString(),
+  node: process.version,
+  platform: process.platform,
+  arch: process.arch,
+  hyperfine: HYPERFINE_VERSION,
+  smoke,
+  sessionIterations,
+  scenarios: ["cli-version", "cold-server", "warm-session"],
+};
+await writeFile(path.join(outputDir, "metadata.json"), `${JSON.stringify(metadata, null, 2)}\n`, "utf8");
+console.log(`Performance evidence: ${outputDir}`);
+
+function runHyperfine(args) {
+  const result = spawnSync("hyperfine", args, { cwd: root, env, stdio: "inherit" });
+  if (result.error) throw result.error;
+  if (result.status !== 0) throw new Error(`hyperfine exited with status ${String(result.status)}`);
+}
+
+function runScenario(command, required = true) {
+  const result = spawnSync(process.execPath, ["scripts/performance/scenario.js", command], {
+    cwd: root,
+    env,
+    encoding: "utf8",
+  });
+  if (result.error && required) throw result.error;
+  if (result.status !== 0 && required) throw new Error(result.stderr.trim() || `${command} failed`);
+}
+
+function commandOutput(command, args) {
+  const result = spawnSync(command, args, { cwd: root, encoding: "utf8" });
+  if (result.error) return "";
+  return result.stdout.trim();
+}
+
+async function unusedPort() {
+  const server = net.createServer();
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("Could not allocate a benchmark port");
+  await new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+  return address.port;
+}

--- a/scripts/performance/scenario.js
+++ b/scripts/performance/scenario.js
@@ -1,0 +1,187 @@
+// @ts-check
+import { spawn } from "node:child_process";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+const root = path.resolve(import.meta.dirname, "../..");
+const command = process.argv[2];
+const port = requiredPort("LAVISH_AXI_BENCH_PORT");
+const runtimeDir = requiredAbsolutePath("LAVISH_AXI_BENCH_RUNTIME_DIR");
+const stateDir = requiredAbsolutePath("LAVISH_AXI_BENCH_STATE_DIR");
+const fixture = requiredAbsolutePath("LAVISH_AXI_BENCH_FIXTURE");
+const pidFile = path.join(runtimeDir, "server.json");
+const baseUrl = `http://127.0.0.1:${port}`;
+
+if (command === "start-server") {
+  await startServer();
+} else if (command === "stop-server") {
+  await stopServer();
+} else if (command === "warm-session") {
+  await runWarmSessionBatch();
+} else {
+  throw new Error("Usage: node scripts/performance/scenario.js <start-server|stop-server|warm-session>");
+}
+
+async function startServer() {
+  await mkdir(runtimeDir, { recursive: true });
+  await mkdir(stateDir, { recursive: true });
+
+  const existing = await readPidRecord();
+  if (existing && processExists(existing.pid)) {
+    throw new Error(`Benchmark server PID ${existing.pid} is already running`);
+  }
+  await rm(pidFile, { force: true });
+
+  const child = spawn(process.execPath, ["dist/cli.mjs", "server", "--port", String(port)], {
+    cwd: root,
+    detached: true,
+    env: {
+      ...process.env,
+      LAVISH_AXI_HOST: "127.0.0.1",
+      LAVISH_AXI_NO_OPEN: "1",
+      LAVISH_AXI_STATE_DIR: stateDir,
+      LAVISH_AXI_TELEMETRY: "0",
+    },
+    stdio: "ignore",
+  });
+  child.unref();
+
+  if (!child.pid) {
+    throw new Error("The benchmark server did not return a process ID");
+  }
+
+  const record = { pid: child.pid, port, stateDir, startedAt: new Date().toISOString() };
+  await writeFile(pidFile, `${JSON.stringify(record, null, 2)}\n`, "utf8");
+
+  try {
+    await waitForHealth(child.pid, 10_000);
+  } catch (error) {
+    await terminateProcess(child.pid);
+    await rm(pidFile, { force: true });
+    throw error;
+  }
+}
+
+async function stopServer() {
+  const record = await readPidRecord();
+  if (!record) return;
+  if (record.port !== port || record.stateDir !== stateDir) {
+    throw new Error("The benchmark server record does not match this benchmark run");
+  }
+
+  try {
+    const health = await fetchJson(`${baseUrl}/health`);
+    if (health?.app === "lavish-axi") {
+      await fetch(`${baseUrl}/shutdown`, { method: "POST" });
+    }
+  } catch {
+    // The exact recorded process remains the cleanup authority when HTTP is unavailable.
+  }
+
+  await waitForExit(record.pid, 2_000);
+  if (processExists(record.pid)) await terminateProcess(record.pid);
+  await rm(pidFile, { force: true });
+  await rm(stateDir, { force: true, recursive: true });
+}
+
+async function runWarmSessionBatch() {
+  const iterations = positiveInteger(process.env.LAVISH_AXI_BENCH_SESSION_ITERATIONS || "25", "iterations");
+  const health = await fetchJson(`${baseUrl}/health`);
+  if (health?.ok !== true || health?.app !== "lavish-axi") {
+    throw new Error("The warm benchmark server is not ready");
+  }
+
+  for (let index = 0; index < iterations; index += 1) {
+    const response = await fetch(`${baseUrl}/api/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ file: fixture }),
+    });
+    if (!response.ok) {
+      throw new Error(`Warm session request failed with HTTP ${response.status}`);
+    }
+    const result = await response.json();
+    if (result.status !== "opened") {
+      throw new Error(`Warm session request returned status ${String(result.status)}`);
+    }
+  }
+}
+
+async function waitForHealth(pid, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!processExists(pid)) throw new Error("The benchmark server exited before it became ready");
+    try {
+      const health = await fetchJson(`${baseUrl}/health`);
+      if (health?.ok === true && health?.app === "lavish-axi") return;
+    } catch {
+      // Startup is still in progress.
+    }
+    await delay(25);
+  }
+  throw new Error(`The benchmark server did not become ready within ${timeoutMs} ms`);
+}
+
+async function fetchJson(url) {
+  const response = await fetch(url, { cache: "no-store" });
+  if (!response.ok) throw new Error(`${url} returned HTTP ${response.status}`);
+  return response.json();
+}
+
+async function readPidRecord() {
+  try {
+    const value = JSON.parse(await readFile(pidFile, "utf8"));
+    if (!Number.isInteger(value.pid) || !Number.isInteger(value.port) || typeof value.stateDir !== "string") {
+      throw new Error("The benchmark server record is invalid");
+    }
+    return value;
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+function processExists(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return Boolean(error && typeof error === "object" && "code" in error && error.code === "EPERM");
+  }
+}
+
+async function terminateProcess(pid) {
+  if (!processExists(pid)) return;
+  process.kill(pid, "SIGTERM");
+  await waitForExit(pid, 2_000);
+  if (processExists(pid)) process.kill(pid, "SIGKILL");
+  await waitForExit(pid, 2_000);
+}
+
+async function waitForExit(pid, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (processExists(pid) && Date.now() < deadline) await delay(25);
+}
+
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function requiredPort(name) {
+  const value = positiveInteger(process.env[name] || "", name);
+  if (value > 65_535) throw new Error(`${name} must be less than 65536`);
+  return value;
+}
+
+function positiveInteger(value, name) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) throw new Error(`${name} must be a positive integer`);
+  return parsed;
+}
+
+function requiredAbsolutePath(name) {
+  const value = process.env[name];
+  if (!value || !path.isAbsolute(value)) throw new Error(`${name} must be an absolute path`);
+  return value;
+}

--- a/scripts/performance/scenario.js
+++ b/scripts/performance/scenario.js
@@ -1,5 +1,6 @@
 // @ts-check
 import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
@@ -33,11 +34,15 @@ async function startServer() {
   }
   await rm(pidFile, { force: true });
 
+  const benchmarkRunId = randomUUID();
+  const exitFile = exitFileFor(benchmarkRunId);
   const child = spawn(process.execPath, ["dist/cli.mjs", "server", "--port", String(port)], {
     cwd: root,
     detached: true,
     env: {
       ...process.env,
+      LAVISH_AXI_BENCH_EXIT_FILE: exitFile,
+      LAVISH_AXI_BENCH_RUN_ID: benchmarkRunId,
       LAVISH_AXI_HOST: "127.0.0.1",
       LAVISH_AXI_NO_OPEN: "1",
       LAVISH_AXI_STATE_DIR: stateDir,
@@ -51,13 +56,13 @@ async function startServer() {
     throw new Error("The benchmark server did not return a process ID");
   }
 
-  const record = { pid: child.pid, port, stateDir, startedAt: new Date().toISOString() };
+  const record = { pid: child.pid, port, stateDir, benchmarkRunId, startedAt: new Date().toISOString() };
   await writeFile(pidFile, `${JSON.stringify(record, null, 2)}\n`, "utf8");
 
   try {
-    await waitForHealth(child.pid, 10_000);
+    await waitForHealth(child.pid, benchmarkRunId, 10_000);
   } catch (error) {
-    await terminateProcess(child.pid);
+    await terminateChild(child);
     await rm(pidFile, { force: true });
     throw error;
   }
@@ -69,26 +74,35 @@ async function stopServer() {
   if (record.port !== port || record.stateDir !== stateDir) {
     throw new Error("The benchmark server record does not match this benchmark run");
   }
-
-  try {
-    const health = await fetchJson(`${baseUrl}/health`);
-    if (health?.app === "lavish-axi") {
-      await fetch(`${baseUrl}/shutdown`, { method: "POST" });
-    }
-  } catch {
-    // The exact recorded process remains the cleanup authority when HTTP is unavailable.
+  const exitFile = exitFileFor(record.benchmarkRunId);
+  if (await hasExitReceipt(exitFile, record)) {
+    await finishCleanup(record.pid);
+    return;
   }
 
-  await waitForExit(record.pid, 2_000);
-  if (processExists(record.pid)) await terminateProcess(record.pid);
-  await rm(pidFile, { force: true });
-  await rm(stateDir, { force: true, recursive: true });
+  const health = await fetchJson(`${baseUrl}/health`);
+  if (health?.benchmarkRunId !== record.benchmarkRunId) {
+    throw new Error("The process on the benchmark port does not match the recorded server identity");
+  }
+  const response = await fetch(`${baseUrl}/shutdown`, {
+    method: "POST",
+    headers: { "x-lavish-benchmark-run-id": record.benchmarkRunId },
+  });
+  if (!response.ok) throw new Error(`Benchmark shutdown returned HTTP ${response.status}`);
+  await waitForExitReceipt(exitFile, record, 4_000);
+  await finishCleanup(record.pid);
 }
 
 async function runWarmSessionBatch() {
   const iterations = positiveInteger(process.env.LAVISH_AXI_BENCH_SESSION_ITERATIONS || "25", "iterations");
   const health = await fetchJson(`${baseUrl}/health`);
-  if (health?.ok !== true || health?.app !== "lavish-axi") {
+  const record = await readPidRecord();
+  if (
+    !record ||
+    health?.ok !== true ||
+    health?.app !== "lavish-axi" ||
+    health?.benchmarkRunId !== record.benchmarkRunId
+  ) {
     throw new Error("The warm benchmark server is not ready");
   }
 
@@ -108,13 +122,13 @@ async function runWarmSessionBatch() {
   }
 }
 
-async function waitForHealth(pid, timeoutMs) {
+async function waitForHealth(pid, benchmarkRunId, timeoutMs) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (!processExists(pid)) throw new Error("The benchmark server exited before it became ready");
     try {
       const health = await fetchJson(`${baseUrl}/health`);
-      if (health?.ok === true && health?.app === "lavish-axi") return;
+      if (health?.ok === true && health?.app === "lavish-axi" && health?.benchmarkRunId === benchmarkRunId) return;
     } catch {
       // Startup is still in progress.
     }
@@ -132,7 +146,13 @@ async function fetchJson(url) {
 async function readPidRecord() {
   try {
     const value = JSON.parse(await readFile(pidFile, "utf8"));
-    if (!Number.isInteger(value.pid) || !Number.isInteger(value.port) || typeof value.stateDir !== "string") {
+    if (
+      !Number.isInteger(value.pid) ||
+      !Number.isInteger(value.port) ||
+      typeof value.stateDir !== "string" ||
+      typeof value.benchmarkRunId !== "string" ||
+      !/^[0-9a-f-]{36}$/.test(value.benchmarkRunId)
+    ) {
       throw new Error("The benchmark server record is invalid");
     }
     return value;
@@ -151,17 +171,58 @@ function processExists(pid) {
   }
 }
 
-async function terminateProcess(pid) {
-  if (!processExists(pid)) return;
-  process.kill(pid, "SIGTERM");
-  await waitForExit(pid, 2_000);
-  if (processExists(pid)) process.kill(pid, "SIGKILL");
-  await waitForExit(pid, 2_000);
+async function terminateChild(child) {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  child.kill("SIGTERM");
+  await waitForChildExit(child, 2_000);
+  if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+  await waitForChildExit(child, 2_000);
+  if (child.exitCode === null && child.signalCode === null) {
+    throw new Error("The benchmark server child remained alive after bounded cleanup");
+  }
 }
 
-async function waitForExit(pid, timeoutMs) {
+async function waitForProcessExit(pid, timeoutMs) {
   const deadline = Date.now() + timeoutMs;
   while (processExists(pid) && Date.now() < deadline) await delay(25);
+}
+
+async function waitForChildExit(child, timeoutMs) {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  await Promise.race([
+    new Promise((resolve) => child.once("exit", resolve)),
+    delay(timeoutMs),
+  ]);
+}
+
+async function waitForExitReceipt(exitFile, record, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await hasExitReceipt(exitFile, record)) return;
+    await delay(25);
+  }
+  throw new Error("The benchmark server did not confirm exit within the cleanup deadline");
+}
+
+async function hasExitReceipt(exitFile, record) {
+  try {
+    const receipt = JSON.parse(await readFile(exitFile, "utf8"));
+    return receipt.benchmarkRunId === record.benchmarkRunId && receipt.pid === record.pid;
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+async function finishCleanup(pid) {
+  await waitForProcessExit(pid, 2_000);
+  if (processExists(pid)) throw new Error(`Benchmark server PID ${pid} remained alive after shutdown`);
+  await rm(pidFile, { force: true });
+  await rm(stateDir, { force: true, recursive: true });
+}
+
+function exitFileFor(benchmarkRunId) {
+  return path.join(runtimeDir, `server-exited-${benchmarkRunId}.json`);
 }
 
 function delay(milliseconds) {

--- a/scripts/performance/scenario.js
+++ b/scripts/performance/scenario.js
@@ -189,10 +189,7 @@ async function waitForProcessExit(pid, timeoutMs) {
 
 async function waitForChildExit(child, timeoutMs) {
   if (child.exitCode !== null || child.signalCode !== null) return;
-  await Promise.race([
-    new Promise((resolve) => child.once("exit", resolve)),
-    delay(timeoutMs),
-  ]);
+  await Promise.race([new Promise((resolve) => child.once("exit", resolve)), delay(timeoutMs)]);
 }
 
 async function waitForExitReceipt(exitFile, record, timeoutMs) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -1033,8 +1033,17 @@ function deepEqual(a, b) {
 async function serverCommand(args) {
   const port = Number(flagValue(args, "--port") || defaultPort());
   const debug = args.includes("--verbose") || process.env.LAVISH_AXI_DEBUG === "1";
-  const server = await serve({ port, stateFile: stateFile(), version: VERSION, debug });
+  const benchmarkRunId = process.env.LAVISH_AXI_BENCH_RUN_ID || "";
+  const benchmarkExitFile = process.env.LAVISH_AXI_BENCH_EXIT_FILE || "";
+  const server = await serve({ port, stateFile: stateFile(), version: VERSION, debug, benchmarkRunId });
   await server.done;
+  if (benchmarkRunId && benchmarkExitFile) {
+    await writeFile(
+      benchmarkExitFile,
+      `${JSON.stringify({ benchmarkRunId, pid: process.pid, stoppedAt: new Date().toISOString() })}\n`,
+      "utf8",
+    );
+  }
   return "";
 }
 

--- a/src/design-reference.js
+++ b/src/design-reference.js
@@ -65,7 +65,7 @@ export const MERMAID_CDN_SNIPPET = `<script type="module">
     return darkQuery.matches;
   }
 
-  const diagrams = [...document.querySelectorAll(".mermaid")].map((el) => ({ el, src: el.textContent }));
+  const diagrams = [...document.querySelectorAll(".mermaid")].map((el) => ({ el, src: el.innerHTML }));
   let applied;
   let rendering = false;
   let queued = false;
@@ -84,7 +84,7 @@ export const MERMAID_CDN_SNIPPET = `<script type="module">
         mermaid.initialize({ startOnLoad: false, theme, securityLevel: "strict" });
         for (const { el, src } of diagrams) {
           el.removeAttribute("data-processed");
-          el.textContent = src;
+          el.innerHTML = src;
         }
         try {
           await mermaid.run({ nodes: diagrams.map((d) => d.el) });

--- a/src/mermaid-source.js
+++ b/src/mermaid-source.js
@@ -43,6 +43,10 @@ function elementHasMermaidClass(node) {
 
 function textContent(node) {
   if (node.nodeName === "#text") return String(node.value || "");
+  // Mermaid treats <br/> inside a quoted label as a meaningful line break.
+  // parse5 represents it as an empty element, so a plain text-content walk
+  // would silently join the text on either side ("OBJECTIVE:do the thing").
+  if (node.tagName === "br") return "<br/>";
   return Array.isArray(node.childNodes) ? node.childNodes.map(textContent).join("") : "";
 }
 

--- a/src/server.js
+++ b/src/server.js
@@ -145,6 +145,7 @@ export async function serve({
   port,
   stateFile,
   version = "",
+  benchmarkRunId = "",
   debug = false,
   log = null,
   pollHeartbeatMs = 15_000,
@@ -211,7 +212,7 @@ export async function serve({
   );
 
   app.get("/health", (req, res) => {
-    res.json({ ok: true, app: "lavish-axi", version });
+    res.json({ ok: true, app: "lavish-axi", version, ...(benchmarkRunId ? { benchmarkRunId } : {}) });
   });
 
   let shutdownResolve;
@@ -220,6 +221,10 @@ export async function serve({
   });
 
   app.post("/shutdown", (req, res) => {
+    if (benchmarkRunId && req.get("x-lavish-benchmark-run-id") !== benchmarkRunId) {
+      res.status(409).json({ error: "benchmark server identity mismatch" });
+      return;
+    }
     res.json({ status: "shutting-down" });
     // Defer until after the response flushes so the client gets confirmation.
     setImmediate(shutdown);

--- a/task-evidence/mermaid-theme/after.html
+++ b/task-evidence/mermaid-theme/after.html
@@ -58,7 +58,7 @@
         return darkQuery.matches;
       }
 
-      const diagrams = [...document.querySelectorAll(".mermaid")].map((el) => ({ el, src: el.textContent }));
+      const diagrams = [...document.querySelectorAll(".mermaid")].map((el) => ({ el, src: el.innerHTML }));
       let applied;
       let rendering = false;
       let queued = false;
@@ -77,7 +77,7 @@
             mermaid.initialize({ startOnLoad: false, theme, securityLevel: "strict" });
             for (const { el, src } of diagrams) {
               el.removeAttribute("data-processed");
-              el.textContent = src;
+              el.innerHTML = src;
             }
             try {
               await mermaid.run({ nodes: diagrams.map((d) => d.el) });

--- a/test/cli-output.test.js
+++ b/test/cli-output.test.js
@@ -498,6 +498,7 @@ test("theme-aware Mermaid snippet serializes rapid theme-change renders", async 
   let nextRenderError;
   let activeRenders = 0;
   let maxActiveRenders = 0;
+  const renderedSources = [];
   let bodyColor = "white";
   let rootColor = "white";
   let rootColorScheme = "normal";
@@ -518,8 +519,20 @@ test("theme-aware Mermaid snippet serializes rapid theme-change renders", async 
       return { data: colors[this.color] };
     },
   };
+  let diagramMarkup = 'flowchart TD\\n  A["OBJECTIVE:<br/>do the thing"]';
   const diagram = {
-    textContent: "flowchart TD\\n  A --> B",
+    get innerHTML() {
+      return diagramMarkup;
+    },
+    set innerHTML(value) {
+      diagramMarkup = value;
+    },
+    get textContent() {
+      return diagramMarkup.replace(/<br\s*\/?\s*>/gi, "");
+    },
+    set textContent(value) {
+      diagramMarkup = value;
+    },
     removeAttribute() {},
   };
   const document = {
@@ -567,6 +580,7 @@ test("theme-aware Mermaid snippet serializes rapid theme-change renders", async 
       initializedThemes.push(theme);
     },
     run() {
+      renderedSources.push(diagram.innerHTML);
       activeRenders += 1;
       maxActiveRenders = Math.max(maxActiveRenders, activeRenders);
       if (nextRenderError) {
@@ -611,6 +625,7 @@ test("theme-aware Mermaid snippet serializes rapid theme-change renders", async 
   assert.equal(typeof transitionListener?.callback, "function");
   assert.equal(transitionListener?.capture, true);
   assert.deepEqual(initializedThemes, ["default"]);
+  assert.deepEqual(renderedSources, ['flowchart TD\\n  A["OBJECTIVE:<br/>do the thing"]']);
   bodyColor = "white-40";
   rootColor = "black";
   transitionListener.callback({ propertyName: "color" });

--- a/test/fixtures/performance/minimal.html
+++ b/test/fixtures/performance/minimal.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Lavish performance fixture</title>
+  </head>
+  <body>
+    <main>
+      <h1>Performance fixture</h1>
+      <p>This artifact gives the session benchmark a stable file.</p>
+    </main>
+  </body>
+</html>

--- a/test/mermaid-source.test.js
+++ b/test/mermaid-source.test.js
@@ -62,6 +62,16 @@ test("extractMermaidSources strips stray inner markup", () => {
   assert.equal(extractMermaidSources(html)[0].source, "graph TD; A-->B");
 });
 
+test("extractMermaidSources preserves line breaks inside Mermaid labels", () => {
+  const html = `<div class="mermaid">flowchart TD
+  A["OBJECTIVE:<br/>do the thing"]</div>`;
+  assert.equal(
+    extractMermaidSources(html)[0].source,
+    `flowchart TD
+  A["OBJECTIVE:<br/>do the thing"]`,
+  );
+});
+
 test("extractMermaidSources handles single-quoted class attributes and empty input", () => {
   assert.equal(extractMermaidSources(`<div class='mermaid x'>graph TD; A-->B</div>`).length, 1);
   assert.deepEqual(extractMermaidSources(""), []);

--- a/test/package-json.test.js
+++ b/test/package-json.test.js
@@ -8,6 +8,7 @@ test("check script runs all verification commands", async () => {
 
   assert.deepEqual(checkCommands, [
     "npm run build",
+    "npm run size:check",
     "npm run lint",
     "npm run format:check",
     "npm run typecheck",

--- a/test/performance-tooling.test.js
+++ b/test/performance-tooling.test.js
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtemp, readFile } from "node:fs/promises";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
@@ -45,7 +45,11 @@ test("the process scenarios start, exercise, and stop their exact benchmark serv
     LAVISH_AXI_BENCH_SESSION_ITERATIONS: "3",
   };
 
-  t.after(() => {
+  let pidRecord;
+  t.after(async () => {
+    if (pidRecord) {
+      await writeFile(path.join(runtimeDir, "server.json"), `${JSON.stringify(pidRecord)}\n`).catch(() => {});
+    }
     runScenario("stop-server", env);
   });
 
@@ -55,10 +59,21 @@ test("the process scenarios start, exercise, and stop their exact benchmark serv
   const health = await fetch(`http://127.0.0.1:${port}/health`).then((response) => response.json());
   assert.deepEqual({ ok: health.ok, app: health.app }, { ok: true, app: "lavish-axi" });
 
-  const pidRecord = JSON.parse(await readFile(path.join(runtimeDir, "server.json"), "utf8"));
+  pidRecord = JSON.parse(await readFile(path.join(runtimeDir, "server.json"), "utf8"));
   assert.equal(pidRecord.port, port);
   assert.equal(pidRecord.stateDir, stateDir);
   assert.ok(Number.isInteger(pidRecord.pid));
+  assert.equal(health.benchmarkRunId, pidRecord.benchmarkRunId);
+
+  await writeFile(
+    path.join(runtimeDir, "server.json"),
+    `${JSON.stringify({ ...pidRecord, benchmarkRunId: "00000000-0000-0000-0000-000000000000" })}\n`,
+  );
+  const rejectedStop = runScenario("stop-server", env);
+  assert.notEqual(rejectedStop.status, 0);
+  const stillRunning = await fetch(`http://127.0.0.1:${port}/health`).then((response) => response.json());
+  assert.equal(stillRunning.benchmarkRunId, pidRecord.benchmarkRunId);
+  await writeFile(path.join(runtimeDir, "server.json"), `${JSON.stringify(pidRecord)}\n`);
 
   const warmed = runScenario("warm-session", env);
   assert.equal(warmed.status, 0, warmed.stderr);

--- a/test/performance-tooling.test.js
+++ b/test/performance-tooling.test.js
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, readFile } from "node:fs/promises";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const root = path.resolve(import.meta.dirname, "..");
+const scenario = path.join(root, "scripts/performance/scenario.js");
+const fixture = path.join(root, "test/fixtures/performance/minimal.html");
+
+async function unusedPort() {
+  const server = net.createServer();
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  await new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+  return address.port;
+}
+
+function runScenario(command, env) {
+  return spawnSync(process.execPath, [scenario, command], {
+    cwd: root,
+    encoding: "utf8",
+    env,
+    timeout: 15_000,
+  });
+}
+
+test("the process scenarios start, exercise, and stop their exact benchmark server", async (t) => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "lavish-performance-test-"));
+  const runtimeDir = path.join(tempDir, "runtime");
+  const stateDir = path.join(tempDir, "state");
+  const port = await unusedPort();
+  const env = {
+    ...process.env,
+    LAVISH_AXI_BENCH_PORT: String(port),
+    LAVISH_AXI_BENCH_RUNTIME_DIR: runtimeDir,
+    LAVISH_AXI_BENCH_STATE_DIR: stateDir,
+    LAVISH_AXI_BENCH_FIXTURE: fixture,
+    LAVISH_AXI_BENCH_SESSION_ITERATIONS: "3",
+  };
+
+  t.after(() => {
+    runScenario("stop-server", env);
+  });
+
+  const started = runScenario("start-server", env);
+  assert.equal(started.status, 0, started.stderr);
+
+  const health = await fetch(`http://127.0.0.1:${port}/health`).then((response) => response.json());
+  assert.deepEqual({ ok: health.ok, app: health.app }, { ok: true, app: "lavish-axi" });
+
+  const pidRecord = JSON.parse(await readFile(path.join(runtimeDir, "server.json"), "utf8"));
+  assert.equal(pidRecord.port, port);
+  assert.equal(pidRecord.stateDir, stateDir);
+  assert.ok(Number.isInteger(pidRecord.pid));
+
+  const warmed = runScenario("warm-session", env);
+  assert.equal(warmed.status, 0, warmed.stderr);
+
+  const stopped = runScenario("stop-server", env);
+  assert.equal(stopped.status, 0, stopped.stderr);
+  await assert.rejects(fetch(`http://127.0.0.1:${port}/health`));
+});

--- a/test/server-whiteboard.test.js
+++ b/test/server-whiteboard.test.js
@@ -19,7 +19,7 @@ import { mermaidSourceHash } from "../src/mermaid-source.js";
 const ARTIFACT_HTML = `<!doctype html><html><body>
 <h1>Demo</h1>
 <pre class="mermaid">flowchart TD
-  A[Start] --&gt; B{Ready?}</pre>
+  A["OBJECTIVE:<br/>do the thing"] --&gt; B{Ready?}</pre>
 <pre class="mermaid">sequenceDiagram
   CLI-&gt;&gt;Server: poll</pre>
 </body></html>`;
@@ -107,14 +107,15 @@ test("whiteboard channel tokens are signed, session bound, and short lived", () 
   assert.equal(isValidWhiteboardChannelToken(createWhiteboardChannelToken(secret, "", now), secret, "", now), false);
 });
 
-test("GET /api/:key/mermaid-sources extracts ordered, entity-decoded sources with hashes", async () => {
+test("GET /api/:key/mermaid-sources preserves label breaks and returns ordered sources with hashes", async () => {
   const ctx = await startWhiteboardServer();
   try {
     const data = await fetch(`${ctx.base}/api/${ctx.key}/mermaid-sources`).then((res) => res.json());
     assert.equal(data.sources.length, 2);
     assert.equal(data.sources[0].index, 0);
-    assert.equal(data.sources[0].source, "flowchart TD\n  A[Start] --> B{Ready?}");
-    assert.equal(data.sources[0].hash, mermaidSourceHash("flowchart TD\n  A[Start] --> B{Ready?}"));
+    const expectedFlowchart = 'flowchart TD\n  A["OBJECTIVE:<br/>do the thing"] --> B{Ready?}';
+    assert.equal(data.sources[0].source, expectedFlowchart);
+    assert.equal(data.sources[0].hash, mermaidSourceHash(expectedFlowchart));
     assert.equal(data.sources[1].source, "sequenceDiagram\n  CLI->>Server: poll");
   } finally {
     await ctx.close();


### PR DESCRIPTION
## Intent

Implement the ratified local OpenSpec for lightweight performance budgets in our lavish-axi fork, then publish and merge it through the automated review and CI ceremony. Strongly prefer existing frameworks that are not bloated instead of a hand-written benchmark framework: Hyperfine owns process sampling and statistics, Size Limit owns deterministic raw-byte budgets, and esbuild owns bundle attribution. Keep repeated process timing out of pnpm run check, leave timing changes report-only until the runner and thresholds are qualified, defer browser timing until a browser-owned requirement exists, and make each Lavish-specific lifecycle adapter use bounded readiness and exact cleanup. Target and merge our fork, not the upstream repository.

## What Changed

- Enforce raw-byte size budgets for CLI, Chrome, design, whiteboard, and published-package outputs in local checks and CI, with esbuild bundle attribution.
- Add report-only Hyperfine benchmarks for CLI startup, cold-server startup, and warm sessions, using bounded readiness and identity-checked cleanup.
- Preserve `<br/>` line breaks in Mermaid labels during source extraction and theme re-rendering.

## Risk Assessment

⚠️ Medium: The benchmark lifecycle and cleanup fixes are well bounded, but the deterministic budget gate conflicts with the repository's declared Node support range and can disrupt supported contributor environments.

## Testing

No prior baseline commands were supplied. Focused tests exercised the exact-server lifecycle and check-script contract; Size Limit enforced all six deterministic raw-byte budgets, Hyperfine 1.20.0 recorded report-only CLI startup, bounded cold-server, and warm-session measurements for target commit e22e41f, and esbuild produced bundle attribution. No browser evidence was captured because the requested performance-budget behavior is exposed through CLI reports and generated JSON rather than a UI.

<details>
<summary>Evidence: Size Limit raw-byte budget report</summary>

```text
$ size-limit
(node:4349) ExperimentalWarning: glob is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
  
  [1mCLI bundle[22m
  Size limit: [32m[1m450 kB[22m[39m
  Size:       [32m[1m421.23 kB[22m[39m
  
  [1mChrome runtime[22m
  Size limit: [32m[1m105 kB[22m[39m
  Size:       [32m[1m98.47 kB[22m[39m
  
  [1mDesign runtime[22m
  Size limit: [32m[1m1.35 MB[22m[39m
  Size:       [32m[1m1.28 MB[22m[39m
  
  [1mWhiteboard JavaScript[22m
  Size limit: [32m[1m8 MB[22m[39m
  Size:       [32m[1m7.65 MB[22m[39m
  
  [1mWhiteboard styles and fonts[22m
  Size limit: [32m[1m720 kB[22m[39m
  Size:       [32m[1m668.7 kB[22m[39m
  
  [1mPublished package payload[22m
  Size limit: [32m[1m15.8 MB[22m[39m
  Size:       [32m[1m15.1 MB[22m[39m
  
```
</details>
<details>
<summary>Evidence: Hyperfine benchmark transcript</summary>

```text
$ npm run build && node scripts/performance/run.js -- --smoke

> lavish-axi@0.1.50 build
> node scripts/build.js

Benchmark 1: node dist/cli.mjs --version
  Time (mean ± σ):     112.1 ms ±  51.2 ms    [User: 75.1 ms, System: 21.7 ms]
  Range (min … max):    75.9 ms … 148.3 ms    2 runs
 
Benchmark 1: node scripts/performance/scenario.js start-server
  Time (mean ± σ):     139.5 ms ±   4.3 ms    [User: 43.4 ms, System: 10.2 ms]
  Range (min … max):   136.5 ms … 142.5 ms    2 runs
 
Benchmark 1: node scripts/performance/scenario.js warm-session
  Time (mean ± σ):      83.1 ms ±   6.3 ms    [User: 69.3 ms, System: 11.2 ms]
  Range (min … max):    78.6 ms …  87.6 ms    2 runs
 
Performance evidence: /var/folders/pt/19wwr80d5bs38zmww5rm2vsc0000gn/T/no-mistakes-evidence/01KZSY3N9P9JR8EGKJ2C7A344V/process-bench/2026-08-12T03-03-07.554Z
```
</details>
<details>
<summary>Evidence: Hyperfine run metadata</summary>

```text
{
  "schemaVersion": 1,
  "commit": "e22e41f72f229a399ee944e7c5431b20f8f9d5c9",
  "recordedAt": "2026-08-12T03:03:09.373Z",
  "node": "v23.5.0",
  "platform": "darwin",
  "arch": "arm64",
  "hyperfine": "1.20.0",
  "smoke": true,
  "sessionIterations": 3,
  "scenarios": [
    "cli-version",
    "cold-server",
    "warm-session"
  ]
}
```
</details>
<details>
<summary>Evidence: CLI startup measurements</summary>

```text
{
  "results": [
    {
      "command": "node dist/cli.mjs --version",
      "mean": 0.11210190230000001,
      "stddev": 0.05123710444298772,
      "median": 0.11210190230000001,
      "user": 0.07509231999999999,
      "system": 0.0216892,
      "min": 0.07587179830000002,
      "max": 0.1483320063,
      "times": [
        0.1483320063,
        0.07587179830000002
      ],
      "memory_usage_byte": [
        66682880,
        66682880
      ],
      "exit_codes": [
        0,
        0
      ]
    }
  ]
}
```
</details>
<details>
<summary>Evidence: Cold-server measurements</summary>

```text
{
  "results": [
    {
      "command": "node scripts/performance/scenario.js start-server",
      "mean": 0.13947177944000003,
      "stddev": 0.004253541445258054,
      "median": 0.13947177944000003,
      "user": 0.0434487,
      "system": 0.01019608,
      "min": 0.13646407144000003,
      "max": 0.14247948744000002,
      "times": [
        0.13646407144000003,
        0.14247948744000002
      ],
      "memory_usage_byte": [
        54755328,
        72597504
      ],
      "exit_codes": [
        0,
        0
      ]
    }
  ]
}
```
</details>
<details>
<summary>Evidence: Warm-session measurements</summary>

```text
{
  "results": [
    {
      "command": "node scripts/performance/scenario.js warm-session",
      "mean": 0.08312020482,
      "stddev": 0.006323361080623542,
      "median": 0.08312020482,
      "user": 0.06930845999999999,
      "system": 0.0111626,
      "min": 0.07864891332,
      "max": 0.08759149632,
      "times": [
        0.08759149632,
        0.07864891332
      ],
      "memory_usage_byte": [
        72777728,
        72777728
      ],
      "exit_codes": [
        0,
        0
      ]
    }
  ]
}
```
</details>
<details>
<summary>Evidence: esbuild bundle attribution report</summary>

```text
$ npm run build && node scripts/performance/analyze-bundles.js

> lavish-axi@0.1.50 build
> node scripts/build.js


cli bundle


  dist/cli.mjs                411.4kb  100.0%
   ├ src/export-bundle.js     121.5kb   29.5%
   ├ src/artifact-sdk.js       65.2kb   15.8%
   ├ src/cli.js                59.7kb   14.5%
   ├ src/server.js             57.3kb   13.9%
   ├ src/design-reference.js   23.5kb    5.7%
   ├ src/session-store.js      22.9kb    5.6%
   ├ src/layout-warnings.js    18.1kb    4.4%
   ├ src/playbooks.js          16.0kb    3.9%
   ├ src/plugin.js              5.5kb    1.3%
   ├ src/telemetry.js           4.7kb    1.1%
   ├ src/whiteboard-store.js    4.6kb    1.1%
   ├ src/html-app.js            2.8kb    0.7%
   ├ src/self-paint.js          2.4kb    0.6%
   ├ src/mermaid-node.js        1.8kb    0.4%
   ├ src/whiteboard-core.js     1.4kb    0.3%
   ├ src/mermaid-source.js      1.3kb    0.3%
   ├ src/paths.js               1.2kb    0.3%
   ├ src/html-transform.js      719b     0.2%
   └ bin/lavish-axi.js           34b     0.0%


whiteboard bundle


  dist/whiteboard/whiteboard.js                                                                                                                                                             7.3mb  100.0%
   ├ node_modules/.pnpm/@excalidraw+excalidraw@0.18.1_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/@excalidraw/excalidraw/dist/prod/chunk-EIO257PC.js                           1.7mb   23.9%
   ├ node_modules/.pnpm/@excalidraw+excalidraw@0.18.1_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/@excalidraw/excalidraw/dist/prod/index.js                                  485.0kb    6.5%
   ├ node_modules/.pnpm/cytoscape@3.34.0/node_modules/cytoscape/dist/cytoscape.esm.mjs                                                                                                    437.0kb    5.9%
   ├ node_modules/.pnpm/@excalidraw+excalidraw@0.18.1_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/@excalidraw/excalidraw/dist/prod/chunk-K2UTITRG.js                         434.8kb    5.8%
   ├ node_modules/.pnpm/katex@0.16.47/node_modules/katex/dist/katex.mjs                                                                                                                   265.0kb    3.5%
   ├ node_modules/.pnpm/react-dom@18.3.1_react@18.3.1/node_modules/react-dom/cjs/react-dom.production.min.js                                                                              128.3kb    1.7%
   ├ node_modules/.pnpm/mermaid@11.12.1/node_modules/mermaid/dist/chunks/mermaid.core/sequenceDiagram-WL72ISMW.mjs                                                                         96.2kb    1.3%
   ├ node_modules/.pnpm/mermaid@11.12.1/node_modules/mermaid/dist/chunks/mermaid.core/chunk-JZLCHNYA.mjs                                                                                   92.2kb    1.2%
   ├ node_modules/.pnpm/mermaid@11.12.1/node_modules/mermaid/dist/chunks/mermaid.core/chunk-ABZYJK2D.mjs                                                                                   91.3kb    1.2%
   ├ node_modules/.pnpm/@excalidraw+excalidraw@0.18.1_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/@excalidraw/excalidraw/dist/prod/locales/uk-UA-QMV73CPH.js                  73.2kb    1.0%
   ├ node_modules/.pnpm/@excalidraw+excalidraw@0.18.1_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/@excalidraw/excalidraw/dist/prod/locales/mr-IN-CRQNXWMA.js                  72.8kb    1.0%
   ├ node_modules/.pnpm/@excalidraw+excalidraw@0.18.1_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/@excalidraw/excalidraw/dist/prod/locales/ru-RU-B4JR7IUQ.js                  70.8kb    0.9%
   ├ node_modules/.pnpm/mermaid@11.12.1/node_modules/mermaid/dist/chunks/mermaid.core/blockDiagram-VD42YOAC.mjs                                                                            70.8kb    0.9%
   ├ node_modules/.pnpm/mermaid@11.12.1/node_modules/mermaid/dist/chunks/mermaid.core/c4Diagram-YG6GDRKO.mjs                                                                               69.6kb    0.9%
   ├ node_modules/.pnpm/@excalidraw+excalidraw@0.18.1_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/@excalidraw/excalidraw/dist/prod/locales/el-GR-BZB4AONW.js                  67.9kb    0.9%
   ├ node_modules/.pnpm/@excalidraw+excalidraw@0.18.1_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/@excalidraw/excalidraw/dist/prod/locales/ku-TR-6OUDTVRD.js                  67.0kb    0.9%
   ├ node_modules/.pnpm/@mermaid-js+parser@0.6.3/node_modules/@mermaid-js/parser/dist/chunks/mermaid-parser.core/chunk-FPAJGGOC.mjs                                                        66.4kb    0.9%
   ├ node_modules/.pnpm/@excalidraw+excalidraw@0.18.1_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/@excalidraw/excalidraw/dist/prod/locales/km-KH-HSX4SM5Z.js                  63.3kb    0.8%
   ├ node_modules/.pnpm/@excalidraw+excalidraw@0.18.1_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/@excalidraw/excalidraw/dist/prod/locales/ta-IN-2NMHFXQM.js                  60.5kb    0.8%
   ├ node_modules/.pnpm/mermaid@11.12.1/node_modules/mermaid/dist/chunks/mermaid.core/flowDiagram-NV44I4VS.mjs                                                                             60.0kb    0.8%
   ├ node_modules/.pnpm/layout-base@2.0.1/node_modules/layout-base/layout-base.js                                                                                                          58.1kb    0.8%
   ├ node_modules/.pnpm/@excalidraw+excalidraw@0.18.1_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/@excalidraw/excalidraw/dist/prod/locales/ar-SA-G6X2FPQ2.js                  56.1kb    0.8%
   ├ node_modules/.pnpm/@excalidraw+excalidraw@0.18.1_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/@excalidraw/excalidraw/dist/prod/locales/hi-IN-IWLTKZ5I.js                  54.0kb    0.7%
   ├ node_modules/.pnpm/@excalidraw+excalidraw@0.18.1_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/@excalidraw/excalidraw/dist/prod/locales/fa-IR-HGAKTJCU.js                  52.1kb    0.7%
   ├ node_modules/.pnpm/layout-base@1.0.2/node_modules/layout-base/layout-base.js                                                                                                          50.8kb    0.7%
   ├ node_modules/.pnpm/@excalidraw+excalidraw@0.18.1_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/@excalidraw/excalidraw/dist/prod/locales/pa-IN-N4M65BXN.js                  45.8kb    0.6%
   ├ node_modules/.pnpm/pako@2.0.3/node_modules/pako/dist/pako.esm.mjs                                                                                                                     45.3kb    0.6%
   ├ node_modules/.pnpm/image-blob-reduce@3.0.1/node_modules/image-blob-reduce/dist/image-blob-reduce.esm.mjs                                                                              45.0kb    0.6%
   ├ node_modules/.pnpm/cose-base@2.2.0/node_modules/cose-base/cose-base.js                                                                                                                44.7kb    0.6%
   ├ node_modules/.pnpm/mermaid@11.12.1/node_modules/mermaid/dist/chunks/mermaid.core/chunk-B4BG7PRW.mjs                                                                                   44.4kb    0.6%
   ├ node_modules/.pnpm/@excalidraw+excalidraw@0.18.1_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/@excalidraw/excalidraw/dist/prod/locales/bg-BG-XCXSNQG7.js                  43.8kb    0.6%
   ├ node_modules/.pnpm/mermaid@11.12.1/node_modules/mermaid/dist/chunks/mermaid.core/chunk-MI3HLSF2.mjs                                                                                   42.4kb    0.6%
   ├ node_modules/.pnpm/@excalidraw+excalidraw@0.18.1_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/@excalidraw/excalidraw/dist/prod/locales/he-IL-6SHJWFNN.js                  41.6kb    0.6%
   ├ node_modules/.pnpm/marked@16.4.2/node_modules/marked/lib/marked.esm.js                                                                        

... [244411 bytes truncated] ...

                       20b     0.0%
   ├ node_modules/.pnpm/@chevrotain+cst-dts-gen@11.0.3/node_modules/@chevrotain/cst-dts-gen/lib/src/generate.js                                                                              18b     0.0%
   ├ node_modules/.pnpm/chevrotain@11.0.3/node_modules/chevrotain/lib/src/version.js                                                                                                         18b     0.0%
   ├ node_modules/.pnpm/d3-brush@3.0.0/node_modules/d3-brush/src/constant.js                                                                                                                 18b     0.0%
   ├ node_modules/.pnpm/d3-brush@3.0.0/node_modules/d3-brush/src/event.js                                                                                                                    18b     0.0%
   ├ node_modules/.pnpm/d3-brush@3.0.0/node_modules/d3-brush/src/noevent.js                                                                                                                  18b     0.0%
   ├ node_modules/.pnpm/d3-chord@3.0.1/node_modules/d3-chord/src/index.js                                                                                                                    18b     0.0%
   ├ node_modules/.pnpm/d3-contour@4.0.2/node_modules/d3-contour/src/index.js                                                                                                                18b     0.0%
   ├ node_modules/.pnpm/d3-delaunay@6.0.4/node_modules/d3-delaunay/src/index.js                                                                                                              18b     0.0%
   ├ node_modules/.pnpm/d3-drag@3.0.0/node_modules/d3-drag/src/index.js                                                                                                                      18b     0.0%
   ├ node_modules/.pnpm/d3-dsv@3.0.1/node_modules/d3-dsv/src/index.js                                                                                                                        18b     0.0%
   ├ node_modules/.pnpm/d3-fetch@3.0.1/node_modules/d3-fetch/src/index.js                                                                                                                    18b     0.0%
   ├ node_modules/.pnpm/d3-force@3.0.0/node_modules/d3-force/src/index.js                                                                                                                    18b     0.0%
   ├ node_modules/.pnpm/d3-geo@3.1.1/node_modules/d3-geo/src/index.js                                                                                                                        18b     0.0%
   ├ node_modules/.pnpm/d3-polygon@3.0.1/node_modules/d3-polygon/src/index.js                                                                                                                18b     0.0%
   ├ node_modules/.pnpm/d3-quadtree@3.0.1/node_modules/d3-quadtree/src/index.js                                                                                                              18b     0.0%
   ├ node_modules/.pnpm/d3-random@3.0.1/node_modules/d3-random/src/index.js                                                                                                                  18b     0.0%
   ├ node_modules/.pnpm/d3-zoom@3.0.0/node_modules/d3-zoom/src/constant.js                                                                                                                   18b     0.0%
   ├ node_modules/.pnpm/d3-zoom@3.0.0/node_modules/d3-zoom/src/event.js                                                                                                                      18b     0.0%
   ├ node_modules/.pnpm/d3-zoom@3.0.0/node_modules/d3-zoom/src/noevent.js                                                                                                                    18b     0.0%
   ├ node_modules/.pnpm/dagre-d3-es@7.0.13/node_modules/dagre-d3-es/src/graphlib/alg/components.js                                                                                           18b     0.0%
   ├ node_modules/.pnpm/dagre-d3-es@7.0.13/node_modules/dagre-d3-es/src/graphlib/alg/tarjan.js                                                                                               18b     0.0%
   ├ node_modules/.pnpm/dagre-d3-es@7.0.13/node_modules/dagre-d3-es/src/graphlib/data/priority-queue.js                                                                                      18b     0.0%
   ├ node_modules/.pnpm/langium@3.3.1/node_modules/langium/lib/languages/language-meta-data.js                                                                                               18b     0.0%
   ├ node_modules/.pnpm/langium@3.3.1/node_modules/langium/lib/parser/parser-config.js                                                                                                       18b     0.0%
   ├ node_modules/.pnpm/langium@3.3.1/node_modules/langium/lib/services.js                                                                                                                   18b     0.0%
   ├ node_modules/.pnpm/nanoid@3.3.3/node_modules/nanoid/url-alphabet/index.js                                                                                                               18b     0.0%
   ├ node_modules/.pnpm/stylis@4.4.0/node_modules/stylis/src/Middleware.js                                                                                                                   18b     0.0%
   ├ node_modules/.pnpm/stylis@4.4.0/node_modules/stylis/src/Prefixer.js                                                                                                                     18b     0.0%
   └ node_modules/.pnpm/react-remove-scroll@2.7.2_react@18.3.1/node_modules/react-remove-scroll/dist/es2015/medium.js                                                                        13b     0.0%

  dist/whiteboard/whiteboard.css                                                                                                                                                          144.5kb  100.0%
   ├ node_modules/.pnpm/@excalidraw+excalidraw@0.18.1_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/@excalidraw/excalidraw/dist/prod/index.css                                 141.2kb   97.7%
   └ src/whiteboard-frame.css                                                                                                                                                               3.3kb    2.3%

  dist/whiteboard/Assistant-Bold-ZDZZ6JHA.woff2                                                                                                                                            19.9kb  100.0%
   └ node_modules/.pnpm/@excalidraw+excalidraw@0.18.1_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/@excalidraw/excalidraw/dist/prod/fonts/Assistant/Assistant-Bold.woff2       19.9kb  100.0%

  dist/whiteboard/Assistant-Medium-DZ25RZU3.woff2                                                                                                                                          19.8kb  100.0%
   └ node_modules/.pnpm/@excalidraw+excalidraw@0.18.1_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/@excalidraw/excalidraw/dist/prod/fonts/Assistant/Assistant-Medium.woff2     19.8kb  100.0%

  dist/whiteboard/Assistant-Regular-PLF2XOGW.woff2                                                                                                                                         19.8kb  100.0%
   └ node_modules/.pnpm/@excalidraw+excalidraw@0.18.1_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/@excalidraw/excalidraw/dist/prod/fonts/Assistant/Assistant-Regular.woff2    19.8kb  100.0%

  dist/whiteboard/Assistant-SemiBold-CZ5MX6FK.woff2                                                                                                                                        19.7kb  100.0%
   └ node_modules/.pnpm/@excalidraw+excalidraw@0.18.1_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/@excalidraw/excalidraw/dist/prod/fonts/Assistant/Assistant-SemiBold.woff2   19.7kb  100.0%
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"cacd6e6f69a1076c32004e5fa8c02029ece47751","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

- 🚨 `scripts/performance/scenario.js:83` - Required criterion “make each Lavish-specific lifecycle adapter use … exact cleanup” is contradicted: cleanup treats the recorded PID as authoritative without verifying process identity. If the benchmark server exits and its PID is reused, this path can SIGTERM/SIGKILL an unrelated process; a different Lavish server that subsequently occupies the port can also satisfy the generic health check and receive `/shutdown`. Bind both HTTP shutdown and signal fallback to a benchmark-specific identity, such as a server nonce plus a verifiable process birth identity.
- 🚨 `scripts/performance/run.js:58` - Required criterion “make each Lavish-specific lifecycle adapter use … exact cleanup” is also contradicted by discarding all final cleanup failures. If `stop-server` cannot terminate the process or rejects the PID record, `runScenario(..., false)` ignores its nonzero status and the benchmark can write successful metadata while leaving the detached server alive. Preserve the primary benchmark failure if present, but require cleanup success before reporting a successful run; the stop adapter should also fail if the recorded process remains alive after its bounded kill sequence.

🔧 Fix: Bind benchmark cleanup to exact server identity
1 warning still open:
- ⚠️ `package.json:60` - The new Size Limit 13.0.3 dependency supports only Node ^22.18, ^24, or &gt;=26, while this package still promises Node &gt;=22. Contributors using Node 22.0–22.17 or Node 23 are therefore within Lavish&#39;s declared range but outside the required budget tool&#39;s range; engine-strict installs can reject it and `pnpm run check` is unsupported there. Either choose a Size Limit release compatible with the existing contract or raise the documented and package engine requirement.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `hyperfine --version`
- `pnpm run build`
- `node --test test/performance-tooling.test.js test/package-json.test.js`
- `pnpm run size:check`
- `LAVISH_AXI_BENCH_OUTPUT_DIR=/var/folders/pt/19wwr80d5bs38zmww5rm2vsc0000gn/T/no-mistakes-evidence/01KZSY3N9P9JR8EGKJ2C7A344V/process-bench pnpm run bench:process -- --smoke`
- `pnpm run size:why`
- `Parsed the generated metadata and Hyperfine result JSON files`
- <code>Verified exact-identity server exit receipts were produced and no live `server.json` remained after cleanup</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
