### PR TITLE
chore(deps): harden pnpm trust policy

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,8 @@
 packages:
   - "."
 
+trustPolicy: no-downgrade
+blockExoticSubdeps: true
 minimumReleaseAge: 10080
 minimumReleaseAgeStrict: true
 minimumReleaseAgeExclude:


### PR DESCRIPTION
## What Changed

- Set `trustPolicy: no-downgrade` in `pnpm-workspace.yaml` so pnpm refuses to lower the resolved trust level of dependencies.
- Enabled `blockExoticSubdeps: true` to block non-registry (exotic) transitive dependencies from being installed.

## Risk Assessment

✅ Low: Adds two valid, recognized pnpm@11.1.1 supply-chain hardening settings whose values are correct and which cannot break the current install (the lockfile has zero exotic subdependencies).

## Testing

This is a config-only supply-chain hardening change with no UI surface, so no visual artifact applies. I confirmed via pnpm's official docs that both `trustPolicy` (value `no-downgrade`) and `blockExoticSubdeps` (boolean) are genuine pnpm settings, then verified the repo's own pnpm 11.1.1 actually recognizes them — `pnpm config list` in the worktree surfaces both as resolved effective config rather than silently dropping them as unknown YAML. A frozen-lockfile offline install under the hardened config completed cleanly including the prepare/build step, confirming the "no runtime behavior change" claim. The `trustPolicy=no-downgrade` failure path only triggers on an actual package downgrade during resolution, which couldn't be safely reproduced offline. All checks passed with no findings; transient install artifacts were cleaned up.

<details>
<summary>Evidence: pnpm trust-policy validation log</summary>

`pnpm config list (worktree) => "trustPolicy": "no-downgrade", "blockExoticSubdeps": true, userAgent pnpm/11.1.1. Docs confirm both are real settings. pnpm@11.1.1 install --frozen-lockfile --offline => Done, exit 0 (no breakage).`

```text
Intent: harden pnpm trust policy in pnpm-workspace.yaml
  trustPolicy: no-downgrade
  blockExoticSubdeps: true

1) Both keys are REAL pnpm settings (pnpm.io/settings/dependency-resolution):
   - trustPolicy valid values: "no-downgrade" | "off" (default off).
     no-downgrade => install fails if a package's trust level decreased vs prior releases.
   - blockExoticSubdeps: boolean => only direct deps may use exotic sources
     (git/tarball URLs); transitive deps must resolve from trusted sources.

2) Repo's actual pnpm 11.1.1 RESOLVES both keys as effective config
   ($ pnpm config list, run in the worktree):
   {
     "blockExoticSubdeps": true,
     ...
     "trustPolicy": "no-downgrade",
     "userAgent": "pnpm/11.1.1 ..."
   }
   => They are recognized config keys, not silently-dropped unknown YAML.

3) End-to-end: hardened config does not break install.
   $ pnpm@11.1.1 install --frozen-lockfile --offline  (in worktree)
   -> devDependencies installed, prepare/build ran, "Done in 2.3s using pnpm v11.1.1", exit 0.
   Confirms the "no runtime behavior change" claim under the real package manager.

Note: trustPolicy=no-downgrade only fails during actual resolution of a
downgraded package; a no-change/frozen install does not exercise the failure
path, so a live downgrade could not be safely reproduced here.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"b0c875568dd42faa73b23243822e20b90b907457","steps":[{"step":"intent","status":"skipped"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`pnpm config list` (in worktree) — confirms pnpm 11.1.1 resolves `trustPolicy: no-downgrade` and `blockExoticSubdeps: true` as effective config</code>
- <code>WebFetch pnpm.io/settings/dependency-resolution — confirmed both keys exist and `no-downgrade` is a valid trustPolicy value</code>
- <code>`pnpm@11.1.1 install --frozen-lockfile --offline` (in worktree) — clean install + prepare/build, exit 0, confirming no runtime behavior change</code>
- <code>Removed transient node_modules and /tmp test dir; `git status --short` clean</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
