### PR TITLE
feat: teach diagrams from zero, one concept at a time

### DIFF
--- a/src/playbooks.js
+++ b/src/playbooks.js
@@ -14,6 +14,8 @@ export const PLAYBOOKS = [
       "For large systems, draw a small overview illustration and put detail in module cards below it, instead of one dense auto-laid graph.",
     ],
     structure: [
+      "Assume the reader knows nothing about the system or concept: explain from zero; do not presume prior familiarity.",
+      "Prefer one concept per diagram: a sequence of simple single-concept illustrations over one dense figure that combines several; layer understanding step by step.",
       "Lead with the question the diagram answers, not with the implementation detail that produced it.",
       "Keep the first visual to the core relationship, then put dense evidence or file references below it.",
       "For complex systems, separate topology from detail so the overview stays readable.",

--- a/test/cli-output.test.js
+++ b/test/cli-output.test.js
@@ -469,6 +469,46 @@ test("diagram playbook defaults to hand-authored SVG and names the anti-patterns
   assert.ok(output.playbook.pitfalls.some((item) => /reach for Mermaid to save authoring effort/i.test(item)));
 });
 
+test("diagram playbook owns assume-nothing and one-concept-per-diagram guidance", async () => {
+  const output = createPlaybookOutput(["diagram"]);
+  assert.ok(
+    output.playbook.structure.some((item) => /knows nothing/i.test(item) && /from zero/i.test(item)),
+    "the diagram playbook must tell agents to explain from zero",
+  );
+  assert.ok(
+    output.playbook.structure.some((item) => /one concept per diagram/i.test(item)),
+    "the diagram playbook must prefer one concept per diagram",
+  );
+
+  const otherSurfaces = [
+    JSON.stringify(createHomeOutput({ bin: "lavish-axi", sessions: [] })),
+    JSON.stringify(createDesignOutput()),
+    createSkillMarkdown(),
+  ];
+  for (const surface of otherSurfaces) {
+    assert.doesNotMatch(surface, /one concept per diagram/i);
+    assert.doesNotMatch(surface, /knows nothing/i);
+  }
+
+  const stateDir = await mkdtemp(`${os.tmpdir()}/lavish-axi-playbook-diagram-`);
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [fileURLToPath(new URL("../bin/lavish-axi.js", import.meta.url)), "playbook", "diagram"],
+      {
+        cwd: fileURLToPath(new URL("..", import.meta.url)),
+        encoding: "utf8",
+        env: { ...process.env, LAVISH_AXI_STATE_DIR: stateDir },
+      },
+    );
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /knows nothing/i);
+    assert.match(result.stdout, /one concept per diagram/i);
+  } finally {
+    await rm(stateDir, { force: true, recursive: true });
+  }
+});
+
 test("diagram playbook routes whiteboard Mermaid through the theme-aware design snippet", () => {
   const output = createPlaybookOutput(["diagram"]);
 


### PR DESCRIPTION
## Intent

Strengthen lavish-axi's SVG-diagram guidance with a small, focused product tweak (captain 2026-08-24): when explaining something with a diagram, ASSUME THE READER KNOWS NOTHING about it, and PREFER ONE CONCEPT PER DIAGRAM over combining several concepts into a single complex figure.

Bake this intent ONCE, in the single best owner among the lavish CLI instruction surfaces. Candidates from the recent SVG-first work: the lavish-axi design diagram guidance (src/design-reference.js), the diagram playbook lavish-axi playbook diagram (src/playbooks.js), and the CLI visual_guidance (src/cli.js). Find where the existing SVG/illustration diagram guidance lives and add this intent to the MOST FITTING one.

Do NOT scatter it across multiple surfaces. Do NOT put it only in the shipped skill stub - skills/lavish/SKILL.md is a thin CLI-deferring stub generated from src/skill.js, so the guidance belongs in the CLI source the skill points to. If the generated skill regenerates via pnpm run build:skill, keep it in sync (the check gate enforces no drift).

The guidance to add, concise and in the existing voice of the chosen surface:
- Assume the reader knows nothing: explain from zero; do not presume prior familiarity with the system or concept being illustrated.
- One concept per diagram: prefer a sequence of simple single-concept illustrations over one dense figure that combines multiple concepts; layer understanding step by step.
Do not bloat the surface. This complements (does not repeat) the existing SVG-first / illustration-over-words guidance.

Acceptance: the intent is present in the single best CLI instruction surface, in-voice and concise; not scattered; not hidden only in the skill stub; live CLI output (lavish-axi design / lavish-axi playbook diagram / --help as applicable) reflects the new guidance; if a test asserts the guidance, exercise the real CLI/consumer output rather than source-text snapshots.

Implementation choice already made: the diagram playbook (lavish-axi playbook diagram / src/playbooks.js structure) is the single owner, because home visual_guidance and lavish-axi design already defer SVG figure guidance to that playbook. Two concise structure bullets were added there only.

Delivery: yolo off; captain owns the merge (lavish-axi ships to npm); do not merge. Expect a Greptile review.

## What Changed

- Add concise diagram playbook guidance to explain concepts from zero and prefer simple, single-concept diagrams layered step by step.
- Add regression coverage for the live `lavish-axi playbook diagram` output and verify the guidance remains owned by that surface alone.

## Risk Assessment

✅ Low: The change is narrowly scoped, places concise guidance in the designated diagram playbook only, and verifies the real CLI output without introducing source-content-only tests.

## Testing

After restoring locked dependencies, targeted CLI tests passed and live CLI output showed concise explain-from-zero and one-concept-per-diagram guidance only in the diagram playbook; a reviewer-visible CLI transcript was captured, and transient build artifacts were cleaned up.

<details>
<summary>Evidence: Live `lavish-axi playbook diagram` CLI output</summary>

Source: [Live `lavish-axi playbook diagram` CLI output](https://github.com/kunchenguid/lavish-axi/blob/e64a84490aa03afd471a9a629be3705d5723ba61/.no-mistakes/evidence/fm/lavish-svg-one-concept-r1/diagram-playbook-cli.txt)

```text
playbook:
  id: diagram
  use_when: "Explain relationships, flows, state, architecture, and concepts with illustrations"
  choose[3]: "Default to hand-authored inline SVG: it gives proportion, emphasis, spatial metaphor, and annotation-ready structure that generated layouts cannot.","Use Mermaid only when the user asks for an editable whiteboard: rendered Mermaid in a `.mermaid` container becomes an Excalidraw whiteboard in the Lavish browser.","For large systems, draw a small overview illustration and put detail in module cards below it, instead of one dense auto-laid graph."
  structure[5]: "Assume the reader knows nothing about the system or concept: explain from zero; do not presume prior familiarity.","Prefer one concept per diagram: a sequence of simple single-concept illustrations over one dense figure that combines several; layer understanding step by step.","Lead with the question the diagram answers, not with the implementation detail that produced it.","Keep the first visual to the core relationship, then put dense evidence or file references below it.","For complex systems, separate topology from detail so the overview stays readable."
  design_rules[7]: "Size with viewBox plus width:100%; never fixed pixel dimensions, and keep every element inside the viewBox.",Color through currentColor and the page's CSS custom properties so figures follow the artifact's light and dark themes.,"Give every meaningful node, edge, and region a stable id and a <title> so reviewers can annotate precisely.","Keep labels to a few words and put prose beside the figure in HTML - SVG text does not wrap, so short labels are also the overflow discipline.","Keep figures self-contained: no external images, fonts, or scripts, so exports render offline.","Render-verify before serving: screenshot the artifact in light, dark, and a narrow viewport - the layout audit deliberately skips SVG interiors.","When the user asked for a whiteboard, initialize Mermaid theme-aware with the `lavish-axi design` snippet rather than hardcoding one theme."
  pitfalls[4]: Do not cram every file or function into one figure when a layered explanation would be clearer.,"Do not hand-build boxes-and-arrows from div/flexbox: inline SVG owns figures, HTML owns the prose around them.","Do not reach for Mermaid to save authoring effort - it surrenders position, size, and emphasis to the engine.",Do not present unverified architecture claims as facts. Cite the files or commands that support them.
  lavish_notes[2]: "A Lavish diagram should invite precise annotation: make modules, edges, and captions easy to click and discuss.","When a relationship is uncertain, label it as a question so the user can resolve it in the review loop."
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ec67cb27f12c16ee81b6d1daaa386fd77b896fbc","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`pnpm install --frozen-lockfile` to restore locked dependencies and run the package prepare build</code>
- `node --test --test-name-pattern "diagram playbook owns assume-nothing and one-concept-per-diagram guidance|diagram playbook defaults to hand-authored SVG and names the anti-patterns|playbook index output lists known playbooks" test/cli-output.test.js`
- <code>Ran `node bin/lavish-axi.js playbook diagram` with isolated state and captured the emitted CLI guidance</code>
- <code>Ran live `lavish-axi --help` and `lavish-axi design` output checks to confirm the new phrases were not duplicated onto those surfaces</code>
- <code>Removed generated `node_modules/` and `dist/` test artifacts and confirmed the worktree remained clean</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
