### PR TITLE
fix: harden whiteboard feedback reliability

### DIFF
--- a/src/whiteboard-core.js
+++ b/src/whiteboard-core.js
@@ -61,9 +61,9 @@ function splitLabelLines(text) {
 function estimateMultilineLabelBox(text, fontSize) {
   const size = Number(fontSize) || 16;
   const lines = splitLabelLines(text);
-  const width = Math.max(
+  const width = lines.reduce(
+    (max, line) => Math.max(max, Math.ceil(Math.max(String(line).length, 1) * size * LABEL_CHAR_WIDTH_RATIO)),
     20,
-    ...lines.map((line) => Math.ceil(Math.max(String(line).length, 1) * size * LABEL_CHAR_WIDTH_RATIO)),
   );
   const height = Math.max(1, lines.length) * size * LABEL_LINE_HEIGHT;
   return { width, height, lineCount: lines.length };

--- a/src/whiteboard-frame.js
+++ b/src/whiteboard-frame.js
@@ -406,8 +406,8 @@ function measureSceneText(element) {
     .replace(/\r\n?/g, "\n")
     .replace(/\t/g, "        ")
     .split("\n");
-  const width = Math.max(...lines.map((line) => textMetricsContext.measureText(line || " ").width));
-  const height = lines.length * (Number(element.fontSize) || 20) * (Number(element.lineHeight) || 1.25);
+  const width = lines.reduce((max, line) => Math.max(max, textMetricsContext.measureText(line || " ").width), 0);
+  const height = Math.max(1, lines.length) * (Number(element.fontSize) || 20) * (Number(element.lineHeight) || 1.25);
   return { width, height };
 }
 

--- a/src/whiteboard-store.js
+++ b/src/whiteboard-store.js
@@ -145,7 +145,10 @@ export function decodePngDataUrl(dataUrl) {
   const match = /^data:image\/png;base64,([A-Za-z0-9+/=]+)$/.exec(String(dataUrl || ""));
   if (!match) return null;
   try {
-    return Buffer.from(match[1], "base64");
+    const png = Buffer.from(match[1], "base64");
+    if (png.length < 8) return null;
+    const signature = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+    return signature.every((byte, index) => png[index] === byte) ? png : null;
   } catch {
     return null;
   }

--- a/test/whiteboard-core.test.js
+++ b/test/whiteboard-core.test.js
@@ -479,8 +479,8 @@ test("restoreMermaidLabelLineBreaks rewrites materialized text elements and size
   const measure = (element) => {
     const lines = String(element.text || "").split("\n");
     return {
-      width: Math.max(...lines.map((line) => line.length * 10)),
-      height: lines.length * (Number(element.fontSize) || 16) * (Number(element.lineHeight) || 1.25),
+      width: lines.reduce((max, line) => Math.max(max, line.length * 10), 0),
+      height: Math.max(1, lines.length) * (Number(element.fontSize) || 16) * (Number(element.lineHeight) || 1.25),
     };
   };
   const [container, text] = restoreMermaidLabelLineBreaks([box, label], { measure });
@@ -511,8 +511,8 @@ test("restoreMermaidLabelLineBreaks recenters bound text when container growth s
   const measure = (element) => {
     const lines = String(element.text || "").split("\n");
     return {
-      width: Math.max(...lines.map((line) => line.length * 10)),
-      height: lines.length * (Number(element.fontSize) || 16) * (Number(element.lineHeight) || 1.25),
+      width: lines.reduce((max, line) => Math.max(max, line.length * 10), 0),
+      height: Math.max(1, lines.length) * (Number(element.fontSize) || 16) * (Number(element.lineHeight) || 1.25),
     };
   };
   const [container, text] = restoreMermaidLabelLineBreaks([box, label], { measure });
@@ -520,6 +520,32 @@ test("restoreMermaidLabelLineBreaks recenters bound text when container growth s
   assert.ok(container.y < box.y, "expandBoxToFit grows from the center, moving the container origin");
   assert.equal(text.x, container.x + (container.width - text.width) / 2);
   assert.equal(text.y, container.y + (container.height - text.height) / 2);
+});
+
+test("restoreMermaidLabelLineBreaks handles empty multiline labels without spreading an empty array", () => {
+  const box = rect("A", { x: 10, y: 20, width: 20, height: 20 });
+  const label = {
+    id: "t1",
+    type: "text",
+    containerId: "A",
+    x: 10,
+    y: 20,
+    width: 0,
+    height: 0,
+    fontSize: 16,
+    lineHeight: 1.25,
+    text: "<br>",
+    originalText: "<br>",
+  };
+  const measure = (element) => {
+    const lines = String(element.text || "").split("\n");
+    return {
+      width: lines.reduce((max, line) => Math.max(max, line.length * 10), 0),
+      height: Math.max(1, lines.length) * (Number(element.fontSize) || 16) * (Number(element.lineHeight) || 1.25),
+    };
+  };
+
+  assert.doesNotThrow(() => restoreMermaidLabelLineBreaks([box, label], { measure }));
 });
 
 test("restoreMermaidLabelLineBreaks leaves labelled-arrow geometry and path-midpoint labels alone", () => {

--- a/test/whiteboard-store.test.js
+++ b/test/whiteboard-store.test.js
@@ -128,9 +128,10 @@ test("writeWhiteboardFeedbackFiles tolerates a missing or invalid preview", asyn
   });
 });
 
-test("decodePngDataUrl only accepts base64 PNG data URLs", () => {
+test("decodePngDataUrl only accepts base64 PNG data URLs with a valid signature", () => {
   assert.ok(decodePngDataUrl(PNG_DATA_URL) instanceof Buffer);
   assert.equal(decodePngDataUrl("data:image/jpeg;base64,abcd"), null);
   assert.equal(decodePngDataUrl("not-a-data-url"), null);
+  assert.equal(decodePngDataUrl("data:image/png;base64,ZmFrZS1wbmc="), null);
   assert.equal(decodePngDataUrl(null), null);
 });


### PR DESCRIPTION
## Summary
- Replace spread-based whiteboard text measurement with reduce-based sizing to avoid crashes on edge-case multiline labels.
- Validate PNG preview data by signature before writing whiteboard feedback sidecars.
- Add regression tests for empty multiline labels and fake PNG data URLs.

## Tests
- `npm test -- test/whiteboard-core.test.js test/whiteboard-store.test.js test/server-whiteboard.test.js`
- `npm run build`
- `npm run lint`
- `npm run format:check`

Note: full `npm test` still has local baseline failures unrelated to this branch: Cursor registration behavior in this environment, and a browser rendering assertion reproduced on `main`.
