### PR TITLE
fix: redact artifact failure paths

### DIFF
--- a/src/session-store.js
+++ b/src/session-store.js
@@ -910,11 +910,18 @@ function normalizeArtifactFailures(failures) {
     .filter((failure) => failure && typeof failure === "object" && !Array.isArray(failure))
     .map((failure) => ({
       kind: String(failure.kind || ""),
-      detail: String(failure.detail || "").slice(0, 300),
+      detail: sanitizeArtifactFailureDetail(failure.detail),
       severity: "fatal",
     }))
     .filter((failure) => ARTIFACT_FAILURE_KINDS.has(failure.kind))
     .slice(0, MAX_ARTIFACT_FAILURES);
+}
+
+function sanitizeArtifactFailureDetail(detail) {
+  return String(detail || "")
+    .replace(/file:\/\/\/[^\s)'"]+/gi, "file://[redacted]")
+    .replace(/(?:[A-Za-z]:)?[\\/](?:[^\s)'"]+[\\/]){2,}[^\s)'"]+/g, "[local path redacted]")
+    .slice(0, 300);
 }
 
 function normalizeTarget(target) {

--- a/test/session-store.test.js
+++ b/test/session-store.test.js
@@ -713,6 +713,37 @@ test("fatal artifact failures still reach the agent without user action", async 
   }
 });
 
+test("artifact failure details redact local file paths before agent delivery", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "lavish-store-"));
+  try {
+    const stateFile = path.join(dir, "state.json");
+    const artifact = path.join(dir, "artifact.html");
+    await writeFile(artifact, "<h1>Hello</h1>");
+
+    const store = new SessionStore(stateFile);
+    const session = await store.upsertSession(artifact, "http://localhost:4387/session/test");
+    const load = await beginArtifactLoad(store, session.key);
+    await store.recordArtifactFailures(session.key, {
+      ...diagnosticPayload(load, 1),
+      failures: [
+        {
+          kind: "artifact-asset-unavailable",
+          detail: "<img> could not load file:///Users/kun/private/logo.png from /Users/kun/private/report.html",
+        },
+      ],
+    });
+
+    const feedback = feedbackResult(await store.takeFeedback(session.key));
+    assert.equal(feedback.artifact_failures.length, 1);
+    assert.equal(
+      feedback.artifact_failures[0].detail,
+      "<img> could not load file://[redacted] from [local path redacted]",
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("stale artifact failures and duplicate diagnostic sequences have no side effects", async () => {
   const dir = await mkdtemp(path.join(tmpdir(), "lavish-store-"));
   try {


### PR DESCRIPTION
## Summary
- Redact local filesystem paths from artifact failure details before they reach poll output.
- Keep safe `/artifact/...` paths intact so missing asset reports stay actionable.
- Add regression coverage for `file://` and absolute local path details.

## Tests
- `npm test -- test/session-store.test.js`
- `npm run build`
- `npm run lint`
