### PR TITLE
fix: return 400 for malformed prompts

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -146,6 +146,10 @@ export function isAttachmentUploadApiPath(pathname) {
   return /^\/api\/[0-9a-f]{16}\/attachments$/.test(String(pathname || ""));
 }
 
+function isValidPromptPayload(body) {
+  return Boolean(body && typeof body === "object" && !Array.isArray(body));
+}
+
 // Read the raw upload body, buffering at most `maxBytes` but always draining the
 // stream to its end. If the body exceeds the cap it resolves `{ tooLarge: true }`
 // (bytes discarded) rather than aborting mid-stream, so the caller can send a clean
@@ -726,6 +730,10 @@ export async function serve({
     try {
       if (!isSameOriginRequest(req, allowedHostnames, allowAnyHostname)) {
         res.status(403).json({ error: "cross-origin prompt submission rejected" });
+        return;
+      }
+      if (!isValidPromptPayload(req.body)) {
+        res.status(400).json({ error: "invalid prompt payload" });
         return;
       }
       const shouldEndSession = Boolean(req.body?.endSession || req.body?.end_session);
@@ -1573,6 +1581,10 @@ export async function serve({
     // Body-parser errors carry a meaningful HTTP status (413 payload-too-large,
     // 400 malformed JSON); surface it instead of flattening everything to 500.
     const status = Number(error?.statusCode || error?.status) || 500;
+    if (status >= 400 && status < 500) {
+      res.status(status).json({ error: "invalid request body" });
+      return;
+    }
     res.status(status).json({ error: error instanceof Error ? error.message : String(error) });
   });
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1878,6 +1878,45 @@ test("loopback server rejects forged non-loopback Host headers (DNS rebinding)",
 // Regression: /api/:key/prompts had no same-origin guard, so any client that
 // learned the (path-derived, non-secret) session key could inject prompts the
 // agent then received as the reviewer's own instructions.
+test("POST /api/:key/prompts rejects malformed bodies with 400", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "lavish-serve-"));
+  const artifact = path.join(dir, "artifact.html");
+  await writeFile(artifact, "<!doctype html><html><body><h1>hi</h1></body></html>");
+  const server = await serve({ port: 0, stateFile: path.join(dir, "state.json"), version: "9.9.9-test" });
+  const base = `http://127.0.0.1:${server.port}`;
+  try {
+    const { key } = await fetch(`${base}/api/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ file: artifact }),
+    }).then((res) => res.json());
+
+    const invalidJson = await fetch(`${base}/api/${key}/prompts`, {
+      method: "POST",
+      headers: { "content-type": "application/json", origin: base },
+      body: "{",
+    });
+    assert.equal(invalidJson.status, 400);
+    assert.deepEqual(await invalidJson.json(), { error: "invalid request body" });
+
+    const invalidShape = await fetch(`${base}/api/${key}/prompts`, {
+      method: "POST",
+      headers: { "content-type": "application/json", origin: base },
+      body: JSON.stringify([]),
+    });
+    assert.equal(invalidShape.status, 400);
+    assert.deepEqual(await invalidShape.json(), { error: "invalid prompt payload" });
+
+    const poll = await fetch(`${base}/api/poll?file=${encodeURIComponent(artifact)}&timeoutMs=0`).then((res) =>
+      res.json(),
+    );
+    assert.equal(poll.status, "waiting");
+  } finally {
+    await server.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("POST /api/:key/prompts rejects non-same-origin callers and queues nothing", async () => {
   const dir = await mkdtemp(path.join(tmpdir(), "lavish-serve-"));
   const artifact = path.join(dir, "artifact.html");


### PR DESCRIPTION
## Summary
- Return clean 400 responses for malformed JSON bodies instead of exposing parser errors.
- Reject non-object prompt payloads before they reach session storage.
- Add regression coverage for malformed `/api/:key/prompts` requests.

## Tests
- `npm test -- test/server.test.js test/session-store.test.js`
- `npm run build`
- `npm run lint`
- `npm run format:check`
