### PR TITLE
fix: attachment upload 500s behind a reverse proxy (x-forwarded-host)

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1485,7 +1485,7 @@ export async function serve({
   // like the whiteboard writes - a hostile cross-origin page must not drive them.
   app.post("/api/:key/attachments", async (req, res, next) => {
     try {
-      if (!isSameOriginRequest(req)) {
+      if (!isSameOriginRequest(req, allowedHostnames, allowAnyHostname)) {
         res.status(403).json({ error: "cross-origin attachment upload rejected" });
         return;
       }
@@ -1547,7 +1547,7 @@ export async function serve({
 
   app.delete("/api/:key/attachments/:id", async (req, res, next) => {
     try {
-      if (!isSameOriginRequest(req)) {
+      if (!isSameOriginRequest(req, allowedHostnames, allowAnyHostname)) {
         res.status(403).json({ error: "cross-origin attachment delete rejected" });
         return;
       }

--- a/test/server-attachments.test.js
+++ b/test/server-attachments.test.js
@@ -18,9 +18,9 @@ const PNG_2x1 = Buffer.from(
 
 /**
  * @param {(ctx: { base: string, key: string, artifact: string }) => Promise<void>} run
- * @param {{ env?: Record<string, string> }} [options]
+ * @param {{ env?: Record<string, string>, allowedHosts?: string[] }} [options]
  */
-async function withSession(run, { env } = {}) {
+async function withSession(run, { env, allowedHosts } = {}) {
   const dir = await mkdtemp(path.join(tmpdir(), "lavish-attach-srv-"));
   const artifact = path.join(dir, "artifact.html");
   await writeFile(artifact, "<!doctype html><html><body></body></html>");
@@ -31,7 +31,12 @@ async function withSession(run, { env } = {}) {
       process.env[name] = value;
     }
   }
-  const server = await serve({ port: 0, stateFile: path.join(dir, "state.json"), version: "9.9.9-test" });
+  const server = await serve({
+    port: 0,
+    stateFile: path.join(dir, "state.json"),
+    version: "9.9.9-test",
+    ...(allowedHosts ? { allowedHosts } : {}),
+  });
   const base = `http://127.0.0.1:${server.port}`;
   try {
     const open = await fetch(`${base}/api/sessions`, {
@@ -162,6 +167,64 @@ test("upload and delete reject cross-origin requests", async () => {
     });
     assert.equal(del.status, 403);
   });
+});
+
+// Non-regression: attachment upload/delete used to call isSameOriginRequest(req)
+// without the Host-allowlist set, so a reverse proxy forwarding x-forwarded-host
+// threw "Cannot read properties of undefined (reading 'has')" and the route 500'd.
+test("proxied attachment upload/delete work behind an allowlisted x-forwarded-host", async () => {
+  await withSession(
+    async ({ base, key }) => {
+      // A proxied upload whose Origin matches the allowlisted forwarded host succeeds.
+      const upload = await fetch(`${base}/api/${key}/attachments`, {
+        method: "POST",
+        headers: {
+          "content-type": "image/png",
+          origin: "https://review.example",
+          "x-forwarded-host": "review.example",
+          "x-forwarded-proto": "https",
+        },
+        body: PNG_2x1,
+      });
+      assert.equal(upload.status, 200);
+      const { attachment } = await upload.json();
+      assert.equal(attachment.type, "image");
+
+      // Proxied delete of that same id succeeds (not a 500) and removes the bytes.
+      const del = await fetch(`${base}/api/${key}/attachments/${attachment.id}`, {
+        method: "DELETE",
+        headers: {
+          origin: "https://review.example",
+          "x-forwarded-host": "review.example",
+          "x-forwarded-proto": "https",
+        },
+      });
+      assert.equal(del.status, 200);
+      assert.deepEqual(await del.json(), { status: "removed" });
+    },
+    { allowedHosts: ["review.example"] },
+  );
+});
+
+// A forwarded host that is not allowlisted must still be refused (403), not blow up
+// with a 500 now that the guard has the allowlist in hand.
+test("proxied attachment upload rejects a non-allowlisted x-forwarded-host with 403", async () => {
+  await withSession(
+    async ({ base, key }) => {
+      const rejected = await fetch(`${base}/api/${key}/attachments`, {
+        method: "POST",
+        headers: {
+          "content-type": "image/png",
+          origin: "https://evil.example",
+          "x-forwarded-host": "evil.example",
+          "x-forwarded-proto": "https",
+        },
+        body: PNG_2x1,
+      });
+      assert.equal(rejected.status, 403);
+    },
+    { allowedHosts: ["review.example"] },
+  );
 });
 
 // Issue a raw HTTP request so we can forge the Host header - browser `fetch`


### PR DESCRIPTION
## What Changed

- The attachment upload (`POST /api/:key/attachments`) and delete (`DELETE /api/:key/attachments/:id`) routes now pass the resolved `allowedHostnames` set and `allowAnyHostname` flag into `isSameOriginRequest`, matching every other same-origin-guarded route.
- This fixes a 500 under a reverse proxy: with `x-forwarded-host` present the guard dereferenced an undefined allowlist (`reading 'has'`), so an allowlisted forwarded host now authenticates correctly instead of crashing, while a non-allowlisted forwarded host is refused with a clean 403.
- Adds regression tests covering a successful proxied upload/delete behind an allowlisted `x-forwarded-host`, and a 403 for a non-allowlisted forwarded host.

## Risk Assessment

✅ Low: The change is a two-line, mechanically correct fix that passes the already-in-scope `allowedHostnames`/`allowAnyHostname` values into `isSameOriginRequest` for the two attachment write routes, eliminating the TypeError (and resulting 500) that occurred when a reverse proxy set `x-forwarded-host` and making both routes consistent with every other same-origin guarded route.

## Testing

I reproduced the reverse-proxy 500 on the attachment upload route by serving with `allowedHosts: ['review.example']` and posting an image with a matching `origin` plus `x-forwarded-host`/`x-forwarded-proto`: the base commit returned HTTP 500 (`Cannot read properties of undefined (reading 'has')`) and the target commit returned 200 with a stored attachment id. I then added two non-regression tests to `test/server-attachments.test.js` — one asserting proxied upload/delete succeed (200), one asserting a non-allowlisted forwarded host is still rejected (403) — and confirmed the new upload/delete test fails at the base commit and passes at the target commit, with the full attachment and server suites green (244 passing). I restored the worktree's `src/server.js` to the fix, left only the new test file as the working change, and removed the transient `node_modules`/`dist` build artifacts my testing created.

<details>
<summary>Evidence: Proxied attachment upload before/after status</summary>

<code>POST /api/:key/attachments origin=https://review.example x-forwarded-host=review.example x-forwarded-proto=https&#10;BASE ffd7aac -&gt; 500 {&#34;error&#34;:&#34;Cannot read properties of undefined (reading &#39;has&#39;)&#34;}&#10;TARGET ed11198 -&gt; 200 {&#34;status&#34;:&#34;stored&#34;,&#34;attachment&#34;:{&#34;id&#34;:&#34;ee7ce0c6...2b9e8276dbc552a.png&#34;,&#34;type&#34;:&#34;image&#34;,...}}</code>

```text
Proxied attachment upload behind an allowlisted x-forwarded-host

POST /api/:key/attachments
  headers: content-type: image/png, origin: https://review.example,
           x-forwarded-host: review.example, x-forwarded-proto: https
  body: 2x1 PNG

BASE commit ffd7aac (before fix):
  status: 500
  body:   {"error":"Cannot read properties of undefined (reading 'has')"}

TARGET commit ed11198 (after fix):
  status: 200
  body:   {"status":"stored","attachment":{"id":"ee7ce0c6…2b9e8276dbc552a.png","type":"image", ...}}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"0b60569c3ad3a34fe4f19bfc53ff113721210615","steps":[{"step":"intent","status":"skipped"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`node --test test/server-attachments.test.js` (17 pass, incl. 2 new proxied-attachment tests)</code>
- <code>`node --test test/server-attachments.test.js test/server.test.js` (244 pass)</code>
- `Manual probe: POST /api/:key/attachments with origin/https x-forwarded-host behind served with allowedHosts=['review.example'] — returned 500 at base commit, 200 at target`
- <code>`node --test --test-name-pattern &#34;proxied attachment&#34; test/server-attachments.test.js` against base commit source — new upload/delete test fails (500), rejection test still 403</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
