### PR TITLE
feat(playbooks): add tracked batch review guidance

### DIFF
--- a/src/playbooks.js
+++ b/src/playbooks.js
@@ -66,6 +66,7 @@ export const PLAYBOOKS = [
     lavish_notes: [
       "A Lavish table should make individual rows easy annotation targets.",
       "If a row implies a follow-up change, include an action control that queues a specific prompt.",
+      "When one action covers multiple rows and completeness matters, also follow the input playbook's tracked batch pattern so the reviewer submits one explicit ID set for item-by-item accounting.",
     ],
   },
   {
@@ -189,10 +190,12 @@ export const PLAYBOOKS = [
     choose: [
       "Use this when the user needs to select, tune, triage, annotate, or edit a structured choice.",
       "Use controls for decisions the user can make faster visually than by writing a prompt.",
+      "Use an opt-in tracked batch when the agent must preserve completeness across a multi-item decision, such as findings to fixes, constraints to implementation, or recommendations to follow-up work.",
       "Use plain annotations when the artifact only needs open-ended feedback.",
     ],
     structure: [
       "Make each decision surface visible: what is being chosen, what the options mean, and what happens next.",
+      "For a tracked batch, give every candidate item a short, stable, visible ID and let the reviewer select or disposition items with editable native controls.",
       "Keep reversible selection state local in the artifact until the user explicitly submits that question.",
       "Pair each question with a Submit or Queue answer control that sends exactly one prompt for the final answer.",
       "Show selected state separately from queued state so the user trusts what will be sent back.",
@@ -204,6 +207,7 @@ export const PLAYBOOKS = [
       "Put data-lavish-action only on custom (non-native) elements that should act like a feedback control - typically a styled div or span you made clickable - so Lavish does not annotate it and shows a pointer cursor instead.",
       "Use data-lavish-question on a question wrapper or pass queueKey when multiple pre-send updates should replace the prior unsent answer for the same question.",
       "Pass options such as tag, text, selector, target, data, queueKey, or element when they help the agent understand exactly what the user chose.",
+      "For a tracked batch, queue the final selected set once in a concise, bounded data.items array; include each item's stable ID, concise label, and requested disposition, and explicitly tell the agent to account for every submitted ID before reporting completion.",
       "Call window.lavish.sendQueuedPrompts() only when the control should immediately send committed feedback instead of waiting for the user to press Send to Agent.",
       "Make queued prompts specific enough that the agent can act without asking a follow-up question.",
       "Keep native browser controls accessible and readable on mobile.",
@@ -217,6 +221,8 @@ export const PLAYBOOKS = [
     lavish_notes: [
       "Lavish is strongest when the artifact becomes a focused review surface and not just a static page.",
       'A native single-choice question should submit the final value: `<form data-lavish-question="plan" onsubmit="event.preventDefault(); const choice = new FormData(event.currentTarget).get(\'plan\'); if (choice) window.lavish.queuePrompt(\'Use the \' + choice + \' plan\', { tag: \'choice\', text: \'Plan: \' + choice, element: event.currentTarget, data: { question: \'plan\', answer: choice } });"><label><input type="radio" name="plan" value="Starter"> Starter</label><label><input type="radio" name="plan" value="Pro"> Pro</label><button type="submit">Queue this answer</button></form>`.',
+      `A tracked batch should submit the final selected set once: <form data-lavish-question="tracked-review" onsubmit="event.preventDefault(); const selected = [...event.currentTarget.querySelectorAll('input[name=items]:checked')].map((input) => ({ id: input.value, label: input.dataset.label, disposition: input.dataset.disposition })); if (selected.length) window.lavish.queuePrompt('Act on every selected item and return an item-by-item receipt. Account for every submitted ID before reporting completion.', { tag: 'tracked-batch', text: 'Apply ' + selected.length + ' selected review items', element: event.currentTarget, data: { items: selected } });"><label><input type="checkbox" name="items" value="R-03" data-label="Preserve rollback behavior" data-disposition="must-address"> R-03 — Preserve rollback behavior</label><label><input type="checkbox" name="items" value="R-08" data-label="Reuse the existing error surface" data-disposition="must-address"> R-08 — Reuse the existing error surface</label><button type="submit">Queue selected items</button></form>`,
+      "The agent's tracked-batch completion receipt must give every submitted ID exactly one outcome: addressed with concrete evidence, deferred with a reason, or rejected with a reason. Evidence may cover several IDs. Before declaring completion, compare the submitted ID set with the receipt ID set and surface every missing ID.",
       "A custom choice UI should make option buttons update local state, then use a separate Queue answer button with data-lavish-action to queue the final selected value.",
       "Use window.lavish.queuePrompt for user intent, not internal analytics or UI-only state changes.",
       "End input paths with an obvious way for the user to send feedback back to the agent.",

--- a/test/cli-output.test.js
+++ b/test/cli-output.test.js
@@ -753,6 +753,40 @@ test("playbook detail output returns focused Lavish-native guidance", () => {
   assert.ok(output.playbook.lavish_notes.some((item) => item.includes("Lavish")));
 });
 
+test("input playbook defines an opt-in tracked batch handoff", () => {
+  const output = createPlaybookOutput(["input"]);
+  const guidance = JSON.stringify(output.playbook);
+  const example = output.playbook.lavish_notes.find((item) => /tag: ['"]tracked-batch/.test(item));
+
+  assert.match(guidance, /multi-item/);
+  assert.match(guidance, /stable, visible ID/);
+  assert.match(guidance, /selected set/);
+  assert.match(guidance, /account for every submitted ID/);
+  assert.match(guidance, /addressed/);
+  assert.match(guidance, /deferred/);
+  assert.match(guidance, /rejected/);
+  assert.match(guidance, /receipt ID set/);
+  assert.ok(example, "the tracked-batch pattern includes a copyable example");
+  assert.match(example, /<form/);
+  assert.match(example, /type="checkbox"/);
+  assert.match(example, /onsubmit=/);
+  assert.equal(example.match(/window\.lavish\.queuePrompt/g)?.length, 1);
+  assert.match(example, /items: selected/);
+  assert.match(example, /id:/);
+  assert.match(example, /label:/);
+  assert.match(example, /disposition:/);
+});
+
+test("table playbook routes multi-row actions to the input tracked-batch pattern", () => {
+  const output = createPlaybookOutput(["table"]);
+
+  assert.ok(
+    output.playbook.lavish_notes.some(
+      (item) => item.includes("multiple rows") && item.includes("input") && item.includes("tracked batch"),
+    ),
+  );
+});
+
 test("code playbook detail output requires verified @pierre/diffs rendering", () => {
   const output = createPlaybookOutput(["code"]);
 


### PR DESCRIPTION
## Intent

Implement issue #326: add an opt-in tracked batch pattern to the existing input playbook for multi-item review decisions, using existing native controls and window.lavish.queuePrompt() rather than new server state. The guidance must use short stable visible item IDs, keep selection local and editable until one deliberate bounded submission, include each selected item's ID, concise label, and requested disposition, and explicitly require the agent to account for every submitted ID. Include a copyable example that queues the final set once, plus completion receipt guidance giving every ID an addressed outcome with evidence, deferred with reason, or rejected with reason, and requiring a submitted-ID versus receipt-ID completeness check that surfaces omissions. Add a short table playbook cross-reference. Keep the pattern generic, opt-in, fail-open, and unchanged for artifacts that do not use it; do not add automatic inference, blocking behavior, persistence, semantic validation, or workflow-specific machinery.

## What Changed

- Add opt-in tracked-batch guidance to the input playbook: editable native selections are submitted once with stable item IDs, labels, and dispositions.
- Define item-by-item completion receipts with submitted-versus-receipt ID checks, plus a table playbook cross-reference and coverage tests.

## Risk Assessment

✅ Low: The change is a bounded opt-in update to emitted playbook guidance, preserves existing runtime behavior, and introduces no server state, blocking, or protected-data path.

## Testing

After restoring the worktree-local dependencies needed for the initially blocked focused test, targeted tests passed; the real CLI emits the tracked-batch guidance and table cross-reference, and the copyable form was browser-executed to confirm one submit queues one payload containing both selected IDs, labels, and dispositions. Temporary worktree dependencies were removed.

<details>
<summary>Evidence: Emitted input playbook guidance</summary>

```text
﻿playbook:
  id: input
  use_when: "Must be used when the agent needs to collect user input on decisions, choices, preferences, triage, scope, or other structured feedback from within the artifact"
  choose[4]: "Use this when the user needs to select, tune, triage, annotate, or edit a structured choice.",Use controls for decisions the user can make faster visually than by writing a prompt.,"Use an opt-in tracked batch when the agent must preserve completeness across a multi-item decision, such as findings to fixes, constraints to implementation, or recommendations to follow-up work.",Use plain annotations when the artifact only needs open-ended feedback.
  structure[5]: "Make each decision surface visible: what is being chosen, what the options mean, and what happens next.","For a tracked batch, give every candidate item a short, stable, visible ID and let the reviewer select or disposition items with editable native controls.",Keep reversible selection state local in the artifact until the user explicitly submits that question.,Pair each question with a Submit or Queue answer control that sends exactly one prompt for the final answer.,Show selected state separately from queued state so the user trusts what will be sent back.
  design_rules[10]: "Native controls - radios, checkboxes, text inputs, selects, textareas, buttons, options, labels, disclosure summaries, and contenteditable regions - are interactive automatically: clicks toggle, focus, and type instead of annotating, so they do not need data-lavish-action. Build choice and option UIs from these whenever you can.","For reversible choices, do not call window.lavish.queuePrompt() from radio change handlers or option click handlers. Those handlers should only update local selected state.",Use a per-question form submit or explicit Queue answer button to read the current values and call window.lavish.queuePrompt() exactly once for the final answer.,Put data-lavish-action only on custom (non-native) elements that should act like a feedback control - typically a styled div or span you made clickable - so Lavish does not annotate it and shows a pointer cursor instead.,Use data-lavish-question on a question wrapper or pass queueKey when multiple pre-send updates should replace the prior unsent answer for the same question.,"Pass options such as tag, text, selector, target, data, queueKey, or element when they help the agent understand exactly what the user chose.","For a tracked batch, queue the final selected set once in a concise, bounded data.items array; include each item's stable ID, concise label, and requested disposition, and explicitly tell the agent to account for every submitted ID before reporting completion.",Call window.lavish.sendQueuedPrompts() only when the control should immediately send committed feedback instead of waiting for the user to press Send to Agent.,Make queued prompts specific enough that the agent can act without asking a follow-up question.,Keep native browser controls accessible and readable on mobile.
  pitfalls[4]: "Do not queue one prompt per radio change, checkbox toggle, dropdown change, or choice-button click when the user can still change their mind.",Do not create controls whose queued prompt is unclear or too vague to execute.,Do not hide the difference between selected locally and queued for the agent.,Do not require interaction for content the user only needs to read.
  lavish_notes[7]: Lavish is strongest when the artifact becomes a focused review surface and not just a static page.,"A native single-choice question should submit the final value: `<form data-lavish-question=\"plan\" onsubmit=\"event.preventDefault(); const choice = new FormData(event.currentTarget).get('plan'); if (choice) window.lavish.queuePrompt('Use the ' + choice + ' plan', { tag: 'choice', text: 'Plan: ' + choice, element: event.currentTarget, data: { question: 'plan', answer: choice } });\"><label><input type=\"radio\" name=\"plan\" value=\"Starter\"> Starter</label><label><input type=\"radio\" name=\"plan\" value=\"Pro\"> Pro</label><button type=\"submit\">Queue this answer</button></form>`.","A tracked batch should submit the final selected set once: <form data-lavish-question=\"tracked-review\" onsubmit=\"event.preventDefault(); const selected = [...event.currentTarget.querySelectorAll('input[name=items]:checked')].map((input) => ({ id: input.value, label: input.dataset.label, disposition: input.dataset.disposition })); if (selected.length) window.lavish.queuePrompt('Act on every selected item and return an item-by-item receipt. Account for every submitted ID before reporting completion.', { tag: 'tracked-batch', text: 'Apply ' + selected.length + ' selected review items', element: event.currentTarget, data: { items: selected } });\"><label><input type=\"checkbox\" name=\"items\" value=\"R-03\" data-label=\"Preserve rollback behavior\" data-disposition=\"must-address\"> R-03 — Preserve rollback behavior</label><label><input type=\"checkbox\" name=\"items\" value=\"R-08\" data-label=\"Reuse the existing error surface\" data-disposition=\"must-address\"> R-08 — Reuse the existing error surface</label><button type=\"submit\">Queue selected items</button></form>","The agent's tracked-batch completion receipt must give every submitted ID exactly one outcome: addressed with concrete evidence, deferred with a reason, or rejected with a reason. Evidence may cover several IDs. Before declaring completion, compare the submitted ID set with the receipt ID set and surface every missing ID.","A custom choice UI should make option buttons update local state, then use a separate Queue answer button with data-lavish-action to queue the final selected value.","Use window.lavish.queuePrompt for user intent, not internal analytics or UI-only state changes.",End input paths with an obvious way for the user to send feedback back to the agent.
```
</details>
<details>
<summary>Evidence: Emitted table cross-reference</summary>

```text
﻿playbook:
  id: table
  use_when: Turn dense records into scan-friendly review surfaces
  choose[3]: Use a table when rows share the same fields and the user needs to compare evidence quickly.,Use cards when each record has a different shape or needs a long explanation.,"Use summaries above the table when counts, risk levels, or statuses change how the table should be read."
  structure[3]: Start with a short summary of what the rows prove or require.,"Group columns by the decision they support: identity, evidence, status, action.","Keep raw details available, but make the primary status visible without reading every cell."
  design_rules[3]: Use semantic table markup when the data is tabular.,"Protect long paths, code symbols, URLs, and prose from overflowing on narrow screens.",Use restrained color for status and severity so the table remains readable when printed or skimmed.
  pitfalls[3]: Do not paste a terminal table into HTML and call it done.,Do not hide the important conclusion below a large undifferentiated grid.,Do not use color as the only status signal.
  lavish_notes[3]: A Lavish table should make individual rows easy annotation targets.,"If a row implies a follow-up change, include an action control that queues a specific prompt.","When one action covers multiple rows and completeness matters, also follow the input playbook's tracked batch pattern so the reviewer submits one explicit ID set for item-by-item accounting."
```
</details>

- Evidence: Executed tracked-batch form queues one structured handoff (local file: <code>~\.no-mistakes\evidence\01M1V53JX1XV6K32FSDMQ5GX7V\tracked-batch-example-executed.png</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"05758b69a13087a0ee591e90c8f80f72d10414df","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`npm install --package-lock=false --ignore-scripts` (worktree-local test dependency setup after initial missing `ws` failure)</code>
- `node --test --test-name-pattern "input playbook defines an opt-in tracked batch handoff|table playbook routes multi-row actions to the input tracked-batch pattern" test/cli-output.test.js`
- <code>`node bin/lavish-axi.js playbook input` and `node bin/lavish-axi.js playbook table`</code>
- `Browser execution of the emitted tracked-batch example: select R-03 and R-08, submit once, and inspect queued payload`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
